### PR TITLE
fallback to environment if decouple config not present

### DIFF
--- a/cis/settings.py
+++ b/cis/settings.py
@@ -1,5 +1,11 @@
+import os
 from decouple import config
 
 
-ARN_MASTER_KEY = config('CIS_ARN_MASTER_KEY')
-DYNAMODB_TABLE = config('CIS_DYNAMODB_TABLE')
+ARN_MASTER_KEY = config(
+    'CIS_ARN_MASTER_KEY', default=os.getenv('CIS_ARN_MASTER_KEY')
+)
+DYNAMODB_TABLE = config(
+    'CIS_DYNAMODB_TABLE',
+    default=os.getenv('CIS_DYNAMODB_TABLE')
+)


### PR DESCRIPTION
This adds a default fall through to the decouple config initialize to support using lambda environment vars instead of settings.ini if necessary.