### PR TITLE
Only allow this publisher to set `groups` data for user

### DIFF
--- a/cis/plugins/validation/mozilliansorg_publisher_plugin.py
+++ b/cis/plugins/validation/mozilliansorg_publisher_plugin.py
@@ -39,8 +39,8 @@ def run(publisher, user, profile_json):
     # Validate that only whitelisted accounts/profiles issued from vetted IdPs (generally, the ones enforcing MFA)
     # can get groups assigned as these are used for access control
     whitelist_idp_with_enforced_mfa = [
-            'github|',  # GitHub has a rule in Auth0 to enforce MFA
-            'ad|'       # = LDAP which enforces Duo MFA in Auth0
+        'github|',  # GitHub has a rule in Auth0 to enforce MFA
+        'ad|'       # = LDAP which enforces Duo MFA in Auth0
     ]
 
     # Check the easiest case. None type.

--- a/cis/plugins/validation/mozilliansorg_publisher_plugin.py
+++ b/cis/plugins/validation/mozilliansorg_publisher_plugin.py
@@ -65,8 +65,8 @@ def run(publisher, user, profile_json):
     new_groups = profile_json.get('groups')
 
     for profile_idp in whitelist_idp_with_enforced_mfa:
-        if profile_json.get('user_id').startswith(profile_idp):
-            if new_groups and len(new_groups) != 0:
+        if not profile_json.get('user_id').startswith(profile_idp):
+            if new_groups:
                 logger.exception('permission denied: publisher {} attempted to set `groups` attribute values for '
                                  'a user profile initiated by an IdP that is not allowed to use '
                                  '`groups`'.format(publisher))


### PR DESCRIPTION
accounts/profiles that were initiated by an IdP that we enforce MFA for,
namely GitHub (github) and LDAP (ad)