### PR TITLE
Convert all the empty values to NULL.

### DIFF
--- a/cis/publisher.py
+++ b/cis/publisher.py
@@ -88,7 +88,7 @@ class ChangeDelegate(object):
             if isinstance(v, dict):
                 v = self._nullify_empty_values(v)
             # explicitly check for None value and empty string.
-            if v is None or v == '':
+            if not v:
                 new[k] = 'NULL'
             else:
                 new[k] = v


### PR DESCRIPTION
Mozillians.org returns for some data empty lists (eg phoneNumbers). This should convert everything to `NULL`. @andrewkrug thoughts?