### PR TITLE
ensure we always load schema no matter what (its not needed if you don't

### DIFF
--- a/python-modules/cis_profile/cis_profile/profile.py
+++ b/python-modules/cis_profile/cis_profile/profile.py
@@ -87,16 +87,17 @@ class User(object):
     """
 
     def __init__(self, user_structure_json=None, user_structure_json_file=None,
-                 discovery_url='https://auth.mozilla.com/.well-known/mozilla-iam', **kwargs):
+                 discovery_url='https://auth.mozilla.com/.well-known/mozilla-iam', schema=None, **kwargs):
         """
         @user_structure_json an existing user structure to load in this class
         @user_structure_json_file an existing user structure to load in this class, from a JSON file
         @discovery_url the well-known Mozilla IAM URL
         @kwargs any user profile attribute name to override on initializing, eg "user_id='test'"
         """
-        self.__schema_loaded = False
-        self.__schema = None
-        self._load_schema(discovery_url)
+        if schema is None:
+            self.__schema = self._load_schema(discovery_url)
+        else:
+            self.__schema = schema
 
         if (user_structure_json is not None):
             self.load(user_structure_json)
@@ -118,6 +119,16 @@ class User(object):
                 logger.error('Unknown user profile attribute {}'.format(kw))
                 raise Exception('Unknown user profile attribute {}'.format(kw))
 
+    def get_schema(self):
+        """
+        Public method to grab the schema. This is useful for external caching of the schema.
+        (E.g. in case this object is destroyed but cache is to be retained
+        """
+        if '__schema' in self.__dict__:
+            return self.__schema
+        else:
+            return None
+
     def _load_schema(self, discovery_url):
         """
         Attempts to fetch latest validation schema, fall-back to cached version on failure.
@@ -125,8 +136,8 @@ class User(object):
         """
 
         # Check cache first
-        if self.__schema is not None:
-            return self._schema
+        if self.get_schema() is not None:
+            return self.get_schema()
 
         schema = None
         schema_url = None
@@ -156,9 +167,6 @@ class User(object):
                 path = schema_file
 
             schema = json.load(open(path))
-
-        self.__schema = schema
-        self.__schema_loaded = True
         return schema
 
     def load(self, profile_json):
@@ -266,8 +274,6 @@ class User(object):
         Validates against a JSON schema
         """
 
-        if not self.__schema_loaded:
-            self._load_schema()
         return jsonschema.validate(self.as_dict(), self.__schema)
 
     def sign_all(self):


### PR DESCRIPTION
validated, but why wouldn't you?)
allow for users of the class to retrieve the cached schema

this makes it possible for module callers to cache the schema externally
instead of re-fetching it on class init