### PR TITLE
Rename uuid dynamo index uuid to user_uuid.

### DIFF
--- a/python-modules/cis_change_service/cis_change_service/profile.py
+++ b/python-modules/cis_change_service/cis_change_service/profile.py
@@ -155,7 +155,7 @@ class Vault(object):
             user_profile = dict(
                 id=profile_json["user_id"]["value"],
                 primary_email=profile_json["primary_email"]["value"],
-                uuid=profile_json["uuid"]["value"],
+                user_uuid=profile_json["uuid"]["value"],
                 primary_username=profile_json["primary_username"]["value"],
                 sequence_number=self.sequence_number,
                 profile=json.dumps(profile_json),
@@ -208,7 +208,7 @@ class Vault(object):
                     user_profile = dict(
                         id=profile_json["user_id"]["value"],
                         primary_email=profile_json["primary_email"]["value"],
-                        uuid=profile_json["uuid"]["value"],
+                        user_uuid=profile_json["uuid"]["value"],
                         primary_username=profile_json["primary_username"]["value"],
                         sequence_number=self.sequence_number,
                         profile=json.dumps(profile_json),
@@ -233,7 +233,7 @@ class Vault(object):
             user_profile = dict(
                 id=profile_json["user_id"]["value"],
                 primary_email=profile_json["primary_email"]["value"],
-                uuid=profile_json["uuid"]["value"],
+                user_uuid=profile_json["uuid"]["value"],
                 primary_username=profile_json["primary_username"]["value"],
                 sequence_number=self.sequence_number,
                 profile=json.dumps(profile_json),

--- a/python-modules/cis_change_service/tests/test_profile.py
+++ b/python-modules/cis_change_service/tests/test_profile.py
@@ -54,7 +54,7 @@ class TestProfile(object):
                 KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
                 AttributeDefinitions=[
                     {"AttributeName": "id", "AttributeType": "S"},
-                    {"AttributeName": "uuid", "AttributeType": "S"},
+                    {"AttributeName": "user_uuid", "AttributeType": "S"},
                     {"AttributeName": "sequence_number", "AttributeType": "S"},
                     {"AttributeName": "primary_email", "AttributeType": "S"},
                     {"AttributeName": "primary_username", "AttributeType": "S"},
@@ -80,8 +80,8 @@ class TestProfile(object):
                         "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                     },
                     {
-                        "IndexName": "{}-uuid".format(name),
-                        "KeySchema": [{"AttributeName": "uuid", "KeyType": "HASH"}],
+                        "IndexName": "{}-user_uuid".format(name),
+                        "KeySchema": [{"AttributeName": "user_uuid", "KeyType": "HASH"}],
                         "Projection": {"ProjectionType": "ALL"},
                         "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                     },

--- a/python-modules/cis_identity_vault/cis_identity_vault/autoscale.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/autoscale.py
@@ -7,7 +7,7 @@ class ScalableTable(object):
         self.config = get_config()
         self._boto_session = None
         self._autoscaling_client = None
-        self.index_names = ["primary_email", "sequence_number", "uuid", "primary_username"]
+        self.index_names = ["primary_email", "sequence_number", "user_uuid", "primary_username"]
         self.max_read_capacity = 100
         self.max_write_capacity = 100
         self.min_read_capactity = 5

--- a/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
@@ -57,7 +57,7 @@ class Profile(object):
             "Put": {
                 "Item": {
                     "id": {"S": user_profile["id"]},
-                    "uuid": {"S": user_profile["uuid"]},
+                    "user_uuid": {"S": user_profile["uuid"]},
                     "profile": {"S": user_profile["profile"]},
                     "primary_email": {"S": user_profile["primary_email"]},
                     "primary_username": {"S": user_profile["primary_username"]},
@@ -89,7 +89,7 @@ class Profile(object):
                     ":sn": {"S": user_profile["sequence_number"]},
                 },
                 "ConditionExpression": "attribute_exists(id)",
-                "UpdateExpression": "SET profile = :p, primary_email = :pe, sequence_number = :sn, uuid = :u, primary_username = :pe",
+                "UpdateExpression": "SET profile = :p, primary_email = :pe, sequence_number = :sn, user_uuid = :u, primary_username = :pe",
                 "TableName": self.table.name,
                 "ReturnValuesOnConditionCheckFailure": "NONE",
             }
@@ -139,7 +139,7 @@ class Profile(object):
                 "Put": {
                     "Item": {
                         "id": {"S": user_profile["id"]},
-                        "uuid": {"S": user_profile["uuid"]},
+                        "user_uuid": {"S": user_profile["uuid"]},
                         "profile": {"S": user_profile["profile"]},
                         "primary_email": {"S": user_profile["primary_email"]},
                         "primary_username": {"S": user_profile["primary_username"]},
@@ -175,7 +175,7 @@ class Profile(object):
                         ":sn": {"S": user_profile["sequence_number"]},
                     },
                     "ConditionExpression": "attribute_exists(id)",
-                    "UpdateExpression": "SET profile = :p, primary_email = :pe, sequence_number = :sn, uuid = :u, primary_username = : pn",
+                    "UpdateExpression": "SET profile = :p, primary_email = :pe, sequence_number = :sn, user_uuid = :u, primary_username = : pn",
                     "TableName": self.table.name,
                     "ReturnValuesOnConditionCheckFailure": "NONE",
                 }
@@ -197,7 +197,7 @@ class Profile(object):
 
     def find_by_uuid(self, uuid):
         result = self.table.query(
-            IndexName="{}-uuid".format(self.table.table_name), KeyConditionExpression=Key("uuid").eq(uuid)
+            IndexName="{}-user_uuid".format(self.table.table_name), KeyConditionExpression=Key("user_uuid").eq(uuid)
         )
         return result
 

--- a/python-modules/cis_identity_vault/cis_identity_vault/vault.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/vault.py
@@ -85,11 +85,16 @@ class IdentityVault(object):
             TableName=self._generate_table_name(),
             KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
             AttributeDefinitions=[
-                {"AttributeName": "id", "AttributeType": "S"},  # auth0 user_id
-                {"AttributeName": "uuid", "AttributeType": "S"},  # uuid formerly dinopark id
-                {"AttributeName": "sequence_number", "AttributeType": "S"},  # sequence number for the last integration
-                {"AttributeName": "primary_email", "AttributeType": "S"},  # value of the primary_email attribute
-                {"AttributeName": "primary_username", "AttributeType": "S"},  # value of the primary_username attribute
+                # auth0 user_id
+                {"AttributeName": "id", "AttributeType": "S"},
+                # user_uuid formerly dinopark id (uuid is a reserverd keyword in dynamo, hence user_uuid)
+                {"AttributeName": "user_uuid", "AttributeType": "S"},
+                # sequence number for the last integration
+                {"AttributeName": "sequence_number", "AttributeType": "S"},
+                # value of the primary_email attribute
+                {"AttributeName": "primary_email", "AttributeType": "S"},
+                # value of the primary_username attribute
+                {"AttributeName": "primary_username", "AttributeType": "S"},
             ],
             ProvisionedThroughput={"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
             GlobalSecondaryIndexes=[
@@ -118,9 +123,9 @@ class IdentityVault(object):
                     "ProvisionedThroughput": {"ReadCapacityUnits": 5, "WriteCapacityUnits": 5},
                 },
                 {
-                    "IndexName": "{}-uuid".format(self._generate_table_name()),
+                    "IndexName": "{}-user_uuid".format(self._generate_table_name()),
                     "KeySchema": [
-                        {"AttributeName": "uuid", "KeyType": "HASH"},
+                        {"AttributeName": "user_uuid", "KeyType": "HASH"},
                         {"AttributeName": "id", "KeyType": "RANGE"},
                     ],
                     "Projection": {"ProjectionType": "ALL"},

--- a/python-modules/cis_identity_vault/tests/test_user_model.py
+++ b/python-modules/cis_identity_vault/tests/test_user_model.py
@@ -20,7 +20,7 @@ class TestUsersDynalite(object):
         self.uuid = self.user_profile["uuid"]["value"]
         self.vault_json_datastructure = {
             "id": self.user_profile.get("user_id").get("value"),
-            "uuid": self.uuid,
+            "user_uuid": self.uuid,
             "primary_email": self.user_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -46,7 +46,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure = {
             "id": modified_profile.get("user_id").get("value"),
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -65,7 +65,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure = {
             "id": modified_profile.get("user_id").get("value"),
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -91,7 +91,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure_first_id = {
             "id": modified_profile.get("user_id").get("value"),
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -104,7 +104,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure_second_id = {
             "id": "foo|mcbar",
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -128,7 +128,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure_first_id = {
             "id": modified_profile.get("user_id").get("value"),
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",
@@ -141,7 +141,7 @@ class TestUsersDynalite(object):
 
         vault_json_datastructure_second_id = {
             "id": "foo|mcbar",
-            "uuid": str(uuid.uuid4()),
+            "user_uuid": str(uuid.uuid4()),
             "primary_email": modified_profile.get("primary_email").get("value"),
             "primary_username": self.user_profile.get("primary_username").get("value"),
             "sequence_number": "12345678",

--- a/python-modules/cis_processor/cis_processor/operation.py
+++ b/python-modules/cis_processor/cis_processor/operation.py
@@ -27,7 +27,7 @@ class BaseProcessor(object):
             "sequence_number": self.event_record["kinesis"]["sequenceNumber"],
             "primary_email": user_profile["primary_email"]["value"],
             "primary_username": user_profile["primary_username"]["value"],
-            "uuid": user_profile["uuid"]["value"],
+            "user_uuid": user_profile["uuid"]["value"],
             "profile": json.dumps(user_profile),
             "id": user_profile["user_id"]["value"],
         }

--- a/python-modules/cis_processor/tests/test_operation.py
+++ b/python-modules/cis_processor/tests/test_operation.py
@@ -36,7 +36,7 @@ def profile_to_vault_structure(user_profile):
         "sequence_number": str(random.randint(100000, 100000000)),
         "primary_email": user_profile["primary_email"]["value"],
         "profile": json.dumps(user_profile),
-        "uuid": user_profile["uuid"]["value"],
+        "user_uuid": user_profile["uuid"]["value"],
         "primary_username": user_profile["primary_username"]["value"],
         "id": user_profile["user_id"]["value"],
     }

--- a/python-modules/cis_processor/tests/test_profile_delegate.py
+++ b/python-modules/cis_processor/tests/test_profile_delegate.py
@@ -15,7 +15,7 @@ def profile_to_vault_structure(user_profile):
         "sequence_number": str(random.randint(100000, 100000000)),
         "primary_email": user_profile["primary_email"]["value"],
         "profile": json.dumps(user_profile),
-        "uuid": user_profile["uuid"]["value"],
+        "user_uuid": user_profile["uuid"]["value"],
         "primary_username": user_profile["primary_username"]["value"],
         "id": user_profile["user_id"]["value"],
     }
@@ -87,7 +87,7 @@ class TestProfileDelegate(object):
             "user_id": {"value": new_user_id},
             "primary_email": {"value": "newzillian@newzilla.com"},
             "primary_username": {"value": "newzillian123"},
-            "uuid": {"value": str(uuid.uuid4())},
+            "user_uuid": {"value": str(uuid.uuid4())},
         }
 
         kinesis_event = kinesis_event_generate(user_profile=new_user_stub)

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/common.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/common.py
@@ -77,7 +77,7 @@ def seed(number_of_fake_users=100):
                 identity_vault_data_structure = {
                     "id": identity.get("user_id").get("value"),
                     "primary_email": identity.get("primary_email").get("value"),
-                    "uuid": identity.get("uuid").get("value"),
+                    "user_uuid": identity.get("uuid").get("value"),
                     "primary_username": identity.get("primary_username").get("value"),
                     "sequence_number": "1234567890",
                     "profile": dumps(identity),


### PR DESCRIPTION
uuid is a reseverd keyword and we cannot perform update
expressions with it. See:
https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html