### PR TITLE
fix signing of null values in e2e

### DIFF
--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -78,7 +78,11 @@ def ensure_appropriate_publishers_and_sign(fake_profile, condition):
             successful_random_publisher = random.choice(publisher_rules[condition][attr])
             temp_profile[attr]["signature"]["publisher"]["name"] = successful_random_publisher
             u = profile.User(user_structure_json=temp_profile)
-            u.sign_attribute(attr, successful_random_publisher)
+            # Don't sign NULL attributes or invalid publishers
+            if u._attribute_value_set(temp_profile[attr], strict=True) and (
+                temp_profile[attr]["signature"]["publisher"]["name"] == successful_random_publisher
+            ):
+                u.sign_attribute(attr, successful_random_publisher)
             temp_profile = u.as_dict()
         else:
             if attr != "schema" and attr in complex_structures:
@@ -93,7 +97,11 @@ def ensure_appropriate_publishers_and_sign(fake_profile, condition):
                     u = profile.User(user_structure_json=temp_profile)
 
                     attribute = "{}.{}".format(attr, k)
-                    u.sign_attribute(attribute, successful_random_publisher)
+                    # Don't sign NULL attributes or invalid publishers
+                    if u._attribute_value_set(temp_profile[attr][k], strict=True) and (
+                        temp_profile[attr][k]["signature"]["publisher"]["name"] == successful_random_publisher
+                    ):
+                        u.sign_attribute(attribute, successful_random_publisher)
                     temp_profile = u.as_dict()
 
     return profile.User(user_structure_json=temp_profile)

--- a/python-modules/cis_profile/cis_profile/profile.py
+++ b/python-modules/cis_profile/cis_profile/profile.py
@@ -462,12 +462,8 @@ class User(object):
     def sign_all(self, publisher_name):
         """
         Sign all child nodes with a non-null value(s) OR empty values (strict=False)
-        To sign empty values, manually call sign_attribute()
         This requires cis_crypto to be properly setup (i.e. with keys)
-
-        WARNING: Since it signs all attributes, this is to be used only when CREATING a new profile. Signing all fields
-        while UPDATING a profile is a sure way to cause a validation failure (since no publisher is allowed to modify
-        all fields)
+        To sign empty values, manually call sign_attribute()
 
         @publisher_name str a publisher name (will be set in signature.publisher.name at signing time)
         """


### PR DESCRIPTION
this copies the logic from `sign_all` - calling the sign function directly allows to sign null in case you want to override functionality (though i dont know how useful it really is in the real world)