### PR TITLE
fixies

### DIFF
--- a/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
@@ -280,7 +280,7 @@ class Profile(object):
         try:
             if len(updates) > 0:
                 res_update = self.update_batch(updates)
-                logger.error("There are {} updates to perform in this batch.".format(len(updates)))
+                logger.debug("There are {} updates to perform in this batch.".format(len(updates)))
             else:
                 res_update = None
         except ClientError as e:

--- a/python-modules/cis_publisher/cis_publisher/ldap.py
+++ b/python-modules/cis_publisher/cis_publisher/ldap.py
@@ -46,6 +46,7 @@ class LDAPPublisher:
         except Exception as e:
             logger.error("Failed to post_all() LDAP profiles. Trace: {}".format(format_exc()))
             raise e
+
         if len(failures) > 0:
             logger.error("Failed to post {} profiles: {}".format(len(failures), failures))
 

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -69,9 +69,12 @@ class Publish:
 
         self.__deferred_init()
         failed_users = []
+        access_token = self._get_authzero_token()
+        qs = "/v2/user"
+        cis_users = self.get_known_cis_users()
 
         if user_ids is not None:
-            logger.info("Requesting a specific list of user_id's to post {}".format(user_ids))
+            logger.info("Requesting a specific list of user_id's to post {} ({})".format(user_ids, len(user_ids)))
             if not isinstance(user_ids, list):
                 raise PublisherError("user_ids must be a list", user_ids)
 
@@ -82,10 +85,6 @@ class Publish:
             logger.info("After filtering, we have {} user profiles to post".format(len(self.profiles)))
 
         #        self.validate()
-
-        access_token = self._get_authzero_token()
-        qs = "/v2/user"
-        cis_users = self.get_known_cis_users()
 
         for profile in self.profiles:
             # New users should also pass this parameter
@@ -114,7 +113,7 @@ class Publish:
                     time.sleep(self.retry_delay)
                     if retries >= self.max_retries:
                         logger.error(
-                            "Maximum retries reached ({}), profile is not be sent {}".format(
+                            "Maximum retries reached ({}), profile is not to be sent {}".format(
                                 retries, profile.user_id.value
                             )
                         )

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -2,6 +2,8 @@ import requests
 import logging
 import os
 import time
+import threading
+import queue
 from cis_profile.common import WellKnown
 from cis_publisher import secret
 from cis_publisher import common
@@ -34,6 +36,7 @@ class Publish:
         self.api_url_person = None
         self.api_url_change = None
         self.max_retries = 3
+        self.max_threads = 50
         # retry_delay is passed to time.sleep
         self.retry_delay = 1
         self.cis_user_list = None
@@ -68,10 +71,10 @@ class Publish:
         """
 
         self.__deferred_init()
-        failed_users = []
-        access_token = self._get_authzero_token()
         qs = "/v2/user"
         cis_users = self.get_known_cis_users()
+        threads = []
+        failed_users = queue.Queue()
 
         if user_ids is not None:
             logger.info("Requesting a specific list of user_id's to post {} ({})".format(user_ids, len(user_ids)))
@@ -84,44 +87,72 @@ class Publish:
                     del self.profiles[n]
             logger.info("After filtering, we have {} user profiles to post".format(len(self.profiles)))
 
+        # XXX - we already validate in the API, is this needed?
         #        self.validate()
 
         for profile in self.profiles:
             # New users should also pass this parameter
             if profile.user_id.value in cis_users:
                 qs = "/v2/user?user_id={}".format(profile.user_id.value)
+            else:
+                qs = "/v2/user"
 
-            response_ok = False
-            retries = 0
-            while not response_ok:
-                logger.info(
-                    "Attempting to post profile {} to API {}{}".format(profile.user_id.value, self.api_url_change, qs)
+            threads.append(threading.Thread(target=self._really_post, args=(qs, profile, failed_users)))
+            threads[-1].start()
+            num_threads = len(threading.enumerate())
+            while num_threads >= self.max_threads:
+                time.sleep(1)
+                num_threads = len(threading.enumerate())
+                logger.info("Too many concurrent threads, waiting a bit...")
+
+        logger.debug("Waiting for threads to terminate...")
+        for t in threads:
+            t.join()
+        logger.debug("Retrieving results from the queue...")
+        ret = []
+        while not failed_users.empty():
+            ret.append(failed_users.get())
+            failed_users.task_done()
+        return ret
+
+    def _really_post(self, qs, profile, failed_users):
+        response_ok = False
+        retries = 0
+        access_token = self._get_authzero_token()
+        while not response_ok:
+            logger.info(
+                "Attempting to post profile {} to API {}{}".format(profile.user_id.value, self.api_url_change, qs)
+            )
+            response = self._request_post(
+                url="{}{}".format(self.api_url_change, qs),
+                payload=profile.as_dict(),
+                headers={"authorization": "Bearer {}".format(access_token)},
+            )
+            response_ok = response.ok
+            if not response_ok:
+                logger.warning(
+                    "Posting profile {} to API failed, retry is {} retry_delay is {} status_code is {} reason is {}"
+                    "contents were {}".format(
+                        profile.user_id.value,
+                        retries,
+                        self.retry_delay,
+                        response.status_code,
+                        response.reason,
+                        response.text,
+                    )
                 )
-                response = self._request_post(
-                    url="{}{}".format(self.api_url_change, qs),
-                    payload=profile.as_dict(),
-                    headers={"authorization": "Bearer {}".format(access_token)},
-                )
-                response_ok = response.ok
-                if not response_ok:
-                    logger.warning(
-                        "Posting profile {} to API failed, retry is {} retry_delay is {}".format(
-                            profile.user_id.value, retries, self.retry_delay
+                retries = retries + 1
+                time.sleep(self.retry_delay)
+                if retries >= self.max_retries:
+                    logger.error(
+                        "Maximum retries reached ({}), profile is not to be sent {}".format(
+                            retries, profile.user_id.value
                         )
                     )
-                    retries = retries + 1
-                    time.sleep(self.retry_delay)
-                    if retries >= self.max_retries:
-                        logger.error(
-                            "Maximum retries reached ({}), profile is not to be sent {}".format(
-                                retries, profile.user_id.value
-                            )
-                        )
-                        failed_users.append(profile.user_id.value)
-                        break
-                else:
-                    logger.info("Profile successfully posted to API {}".format(profile.user_id.value))
-        return failed_users
+                    failed_users.put(profile.user_id.value)
+                    break
+            else:
+                logger.info("Profile successfully posted to API {}".format(profile.user_id.value))
 
     def _request_post(self, url, payload, headers):
         return requests.post(url, json=payload, headers=headers)

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -96,7 +96,7 @@ class Publish:
             retries = 0
             while not response_ok:
                 logger.info(
-                    "Attempting to post profile {} to API {}".format(profile.user_id.value, self.api_url_change)
+                    "Attempting to post profile {} to API {}{}".format(profile.user_id.value, self.api_url_change, qs)
                 )
                 response = self._request_post(
                     url="{}{}".format(self.api_url_change, qs),
@@ -119,6 +119,9 @@ class Publish:
                             )
                         )
                         failed_users.append(profile.user_id.value)
+                        break
+                else:
+                    logger.info("Profile successfully posted to API {}".format(profile.user_id.value))
         return failed_users
 
     def _request_post(self, url, payload, headers):
@@ -187,7 +190,7 @@ class Publish:
             p = self.profiles[n]
             if p.user_id.value in cis_users:
                 logger.info(
-                    "Filtering out non-updateable values from user {} because it already exist in CIS".format(
+                    "Filtering out non-updatable values from user {} because it already exist in CIS".format(
                         p.user_id.value
                     )
                 )

--- a/serverless-functions/Makefile
+++ b/serverless-functions/Makefile
@@ -100,7 +100,10 @@ test-change-service:
 
 .PHONY:deploy-ldap-publisher
 deploy-ldap-publisher:
-	cd $(ROOT_DIR)/ldap-publisher && sls deploy --region $(AWS_REGION) --stage $(STAGE)
+	cd $(ROOT_DIR)/ldap_publisher && \
+	npm install serverless-domain-manager --save-dev serverless-plugin-tracing && \
+	npm install serverless-domain-manager --save-dev && \
+	sls deploy --region $(AWS_REGION) --stage $(STAGE)
 
 .PHONY:deploy-stream-processor
 deploy-stream-processor:

--- a/serverless-functions/ldap_publisher/handler.py
+++ b/serverless-functions/ldap_publisher/handler.py
@@ -26,5 +26,8 @@ def handle(event, context={}):
     """Handle the publishing of users."""
     logger = setup_logging()
     ldap = cis_publisher.ldap.LDAPPublisher()
-    ldap.publish()
+    if isinstance(event, list):
+        ldap.publish(event)
+    else:
+        ldap.publish()
     return 200

--- a/serverless-functions/ldap_publisher/serverless.yml
+++ b/serverless-functions/ldap_publisher/serverless.yml
@@ -85,3 +85,4 @@ functions:
     timeout: 900
     layers:
       -  ${ssm:/iam/cis/${self:custom.ldapPublisherStage}/lambda_layer_arn}
+    reservedConcurrency: 1


### PR DESCRIPTION
This fixes "not sending users" due to a bug sending new users as updates.
This adds concurrency so that up to 50 users are sent to CIS change API at once (configurable in code)
This adds better logging here and there, in particular it will now log the errors from the change API back to the publisher log stream (easier to read/locate)
This limits concurrency to 1 since the function of the publisher is not reentrant (and perform internal concurrency anyway)
Supports sending profiles directly from lambda CLI for tests/fixes/etc as such:
```
aws lambda invoke --function-name ldap-publisher-development-handler:\$LATEST --payload '["ad|Mozilla-LDAP-dev|akrug", "ad|Mozilla-LDAP-dev|gdestuynder"]' --log-type Tail /dev/stdout
```

note: this is currently in the dev deployment