### PR TITLE
fix missing hris attributes from certain users

### DIFF
--- a/docs/PersonAPI.md
+++ b/docs/PersonAPI.md
@@ -33,6 +33,7 @@ classification:workgroup (non-public data)
 classification:workgroup:staff_only (Staff data)
 classification:mozilla_confidential (staff or/and NDA'd data)
 classification:individual (Individual confidential data - most sensitive)
+display:null (fields that do not use the display levels such as `user_id` - this scope is necessary to get them!)
 display:public
 display:authenticated (user indicate this is to be shown only to users that are authenticated with the system)
 display:vouched (user indicate this is to be shown to vouched profiles only)
@@ -43,16 +44,18 @@ read:fullprofile (overrides all classification levels)
 write (scope for CIS Change API which allows profile writes. Note that your signatures still need to match a trusted publisher, and that this scope alone is not sufficient to write data to the API - on it's own it effectively does not grant write access)
 ```
 
-#### Access all public data and workgroup confidential fields that the user expressdly indicated can be shown publicly
+#### Access all public data and workgroup confidential fields that the user expressedly indicated can be shown publicly
 ```
 classification:public
 classification:workgroup
+display:null
 display:public
 ```
 Same, but also get data that the user wants to be only shown to other authenticated users, if you chose to display it back.
 ```
 classification:public
 classification:workgroup
+display:null
 display:public
 display:authenticated
 ```
@@ -61,6 +64,7 @@ display:authenticated
 ```
 classification:public
 classification:workgroup:staff_only
+display:null
 display:public
 display:authenticated
 display:vouched

--- a/python-modules/cis_profile/cis_profile/profile.py
+++ b/python-modules/cis_profile/cis_profile/profile.py
@@ -268,7 +268,7 @@ class User(object):
         """
         self._filter_all(level=self.__dict__, valid=scopes, check="classification")
 
-    def filter_display(self, display_levels=[DisplayLevel.PUBLIC], level=None):
+    def filter_display(self, display_levels=[DisplayLevel.PUBLIC, DisplayLevel.NULL], level=None):
         """
         Filter in place/the current user profile object (self) to only contain attributes with display levels listed
         in @display_levels

--- a/python-modules/cis_publisher/cis_publisher/hris.py
+++ b/python-modules/cis_publisher/cis_publisher/hris.py
@@ -15,7 +15,7 @@ class HRISPublisher:
         self.secret_manager = cis_publisher.secret.Manager()
         self.context = context
 
-    def publish(self, user_ids=None, chunk_size=50):
+    def publish(self, user_ids=None, chunk_size=25):
         """
         Glue to create or fetch cis_profile.User profiles for this publisher
         Then pass everything over to the Publisher class

--- a/python-modules/cis_publisher/cis_publisher/hris.py
+++ b/python-modules/cis_publisher/cis_publisher/hris.py
@@ -82,10 +82,7 @@ class HRISPublisher:
         logger.info("Fetching HRIS report from {}".format(hris_url))
         params = dict(format="json")
 
-        if os.environ.get("CIS_ENVIRONMENT") == "development":
-            res = requests.get(hris_url, params=params)
-        else:
-            res = requests.get(hris_url, auth=requests.auth.HTTPBasicAuth(hris_username, hris_password), params=params)
+        res = requests.get(hris_url, auth=requests.auth.HTTPBasicAuth(hris_username, hris_password), params=params)
 
         del hris_password
         del hris_username

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -90,7 +90,11 @@ class Publish:
 
         logger.info("Received {} user profiles to post".format(len(self.profiles)))
         if user_ids is not None:
-            logger.info("Requesting a specific list of user_id's to post {} ({})".format(user_ids, len(user_ids)))
+            logger.info(
+                "Requesting a specific list of user_id's to post {} (total user_ids: {}, total profiles: {})".format(
+                    user_ids, len(user_ids), len(self.profiles)
+                )
+            )
             if not isinstance(user_ids, list):
                 raise PublisherError("user_ids must be a list", user_ids)
 

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -107,7 +107,7 @@ class Publish:
                         xlist.append(idx)
                 elif profile.user_id.value not in user_ids:
                     xlist.append(idx)
-            for i in reverse(xlist):
+            for i in reversed(xlist):
                 del self.profiles[i]
             logger.info("After filtering, we have {} user profiles to post".format(len(self.profiles)))
 

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -98,13 +98,17 @@ class Publish:
             if not isinstance(user_ids, list):
                 raise PublisherError("user_ids must be a list", user_ids)
 
-            for n in range(0, len(self.profiles)):
-                profile = self.profiles[n]
+            # list what to delete, then delete instead of slower copy list operations or filters
+            # This is because some data sets are huge / GBs of data
+            xlist = []
+            for idx, profile in enumerate(self.profiles):
                 if profile.user_id.value is None:
                     if cis_users_by_email.get(profile.primary_email.value) not in user_ids:
-                        del self.profiles[n]
+                        xlist.append(idx)
                 elif profile.user_id.value not in user_ids:
-                    del self.profiles[n]
+                    xlist.append(idx)
+            for i in reverse(xlist):
+                del self.profiles[i]
             logger.info("After filtering, we have {} user profiles to post".format(len(self.profiles)))
 
         # XXX - we already validate in the API, is this needed?

--- a/python-modules/cis_publisher/tests/test_hris.py
+++ b/python-modules/cis_publisher/tests/test_hris.py
@@ -39,6 +39,15 @@ class TestHRIS(object):
             print(si)
             c = c + 1
 
+    def test_single_user_id(self):
+        hris_data = {}
+        with open("tests/fixture/workday.json") as fd:
+            hris_data = json.load(fd)
+
+        hris = cis_publisher.hris.HRISPublisher()
+        profiles = hris.convert_hris_to_cis_profiles(hris_data, user_ids=["ad|Mozilla-LDAP-Dev|DNoble"])
+        assert profiles[0].access_information.hris["values"]["employee_id"] == "31337"
+
 
 # Not yet supported by moto
 #    def test_reentrancy(self):

--- a/serverless-functions/hris_publisher/serverless.yml
+++ b/serverless-functions/hris_publisher/serverless.yml
@@ -96,4 +96,3 @@ functions:
     timeout: 900
     layers:
       -  ${ssm:/iam/cis/${self:custom.hrisPublisherStage}/lambda_layer_arn}
-    reservedConcurrency: 50

--- a/serverless-functions/hris_publisher/serverless.yml
+++ b/serverless-functions/hris_publisher/serverless.yml
@@ -89,7 +89,7 @@ functions:
     handler: handler.handle
     events:
       - schedule:
-          rate: rate(60 minutes)
+          rate: rate(2 hours)
           enabled: true
     description: hris-publisher for synchronizing HRIS to identity vault.
     memorySize: 1024 # This is HUGE because we load the entirety of users in Memory live.

--- a/serverless-functions/profile_retrieval/serverless.yml
+++ b/serverless-functions/profile_retrieval/serverless.yml
@@ -76,8 +76,8 @@ functions:
   api:
     handler: handler.handle
     description: serverless-wsgi based endpoint to retrieve profiles aka person-api.
-    memorySize: 512
-    timeout: 60
+    memorySize: 3000
+    timeout: 900
     events:
       - http: ANY /
       - http: ANY {proxy+}

--- a/well-known-endpoint/auth0-helper/scopes.json
+++ b/well-known-endpoint/auth0-helper/scopes.json
@@ -55,6 +55,10 @@
           {
                 "value": "display:public",
                 "description": "Read access to data with this display level (classification scope is ALSO needed!)"
+          },
+          {
+                "value": "display:null",
+                "description": "Read access to data with this display level (classification scope is ALSO needed!)"
           }
 	]
 }


### PR DESCRIPTION
note: this fixes hris.py by doing lowercase compares
publisher.py (the generic class) does not need this fix, it fetches user ids from CIS so it has the right id when doing filtering and comparisons

this also adds the filter for `display:null` because i forgot to branch out ./blame kang ; -)