### PR TITLE
Ignore vault updates when there is no real change

### DIFF
--- a/python-modules/cis_change_service/cis_change_service/profile.py
+++ b/python-modules/cis_change_service/cis_change_service/profile.py
@@ -224,7 +224,11 @@ class Vault(object):
         Wrapper for a single profile, calls the batch put_profiles method
         """
         res = self.put_profiles([_profile])
-        if res["creates"] is not None and len(res["creates"]["sequence_numbers"]) == 1:
+        if res["status"] == 202:
+            # 202 means everything went OK but no processing was performed (ie no results and this normal)
+            condition = "noop"
+            sequence_number = None
+        elif res["creates"] is not None and len(res["creates"]["sequence_numbers"]) == 1:
             sequence_number = res["creates"]["sequence_numbers"][0]
             condition = "create"
         elif res["updates"] is not None and len(res["updates"]["sequence_numbers"]) == 1:

--- a/python-modules/cis_change_service/cis_change_service/profile.py
+++ b/python-modules/cis_change_service/cis_change_service/profile.py
@@ -132,7 +132,8 @@ class Vault(object):
             difference = new_user_profile.merge(cis_profile_object)
 
             if (
-                (new_user_profile.active.value == old_user_profile.active.value and difference == ["active"])
+                (difference == ["user_id"])
+                or (new_user_profile.active.value == old_user_profile.active.value and difference == ["active"])
                 or (len(difference) == 0)
                 or (
                     (
@@ -179,7 +180,7 @@ class Vault(object):
                 "A record does not exist in the identity vault for user: {}.".format(user_id),
                 extra={"user_id": user_id},
             )
-            # We raise an exception if uuid oder primary_username is already set. This must not happen.
+            # We raise an exception if uuid or primary_username is already set. This must not happen.
             if cis_profile_object.uuid.value is not None or cis_profile_object.primary_username.value is not None:
                 logger.error(
                     "Trying to create profile, but uuid ({}) or primary_username ({}) was already "

--- a/python-modules/cis_change_service/cis_change_service/profile.py
+++ b/python-modules/cis_change_service/cis_change_service/profile.py
@@ -129,7 +129,28 @@ class Vault(object):
 
             old_user_profile = User(user_structure_json=json.loads(res["Items"][0]["profile"]))
             new_user_profile = copy.deepcopy(old_user_profile)
-            new_user_profile.merge(cis_profile_object)
+            difference = new_user_profile.merge(cis_profile_object)
+
+            if (
+                (new_user_profile.active.value == old_user_profile.active.value and difference == ["active"])
+                or (len(difference) == 0)
+                or (
+                    (
+                        new_user_profile.active.value == old_user_profile.active.value
+                        and (new_user_profile.uuid.value is None and new_user_profile.primary_username.value is None)
+                    )
+                    and sorted(difference) == sorted(["active", "uuid", "primary_username"])
+                )
+            ):
+                logger.info(
+                    "Will not merge user as there were no difference found with the vault instance of the user".format(
+                        extra={"user_id": user_id}
+                    )
+                )
+                return None
+            else:
+                logger.info("Differences found during merge: {}".format(difference), extra={"user_id": user_id})
+
             if self.config("verify_publishers", namespace="cis") == "true":
                 logger.info("Verifying publishers", extra={"user_id": user_id})
                 try:
@@ -161,11 +182,9 @@ class Vault(object):
             # We raise an exception if uuid oder primary_username is already set. This must not happen.
             if cis_profile_object.uuid.value is not None or cis_profile_object.primary_username.value is not None:
                 logger.error(
-                    "Trying to create profile, but uuid or primary_username was already set",
-                    extra={
-                        "user_id": user_id,
-                        "profile": cis_profile_object.as_dict(),
-                    },
+                    "Trying to create profile, but uuid ({}) or primary_username ({}) was already "
+                    "set".format(cis_profile_object.uuid.value, cis_profile_object.primary_username.value),
+                    extra={"user_id": user_id, "profile": cis_profile_object.as_dict()},
                 )
                 raise VerificationError(
                     {
@@ -258,6 +277,13 @@ class Vault(object):
             # Ensure we merge user_profile data when we have an existing user in the vault
             # This also does publisher verification
             current_user = self._search_and_merge(user_id, user_profile)
+            # No difference found, no merging occured, skip!
+            if current_user is None:
+                logger.info(
+                    "User {} already exists and proposed update has no difference, skipping".format(user_id),
+                    extra={"user_id": user_id},
+                )
+                continue
 
             # Check profile signatures
             if self.config("verify_signatures", namespace="cis") == "true":
@@ -281,6 +307,10 @@ class Vault(object):
             current_user = self._update_attr_owned_by_cis(user_id, current_user)
 
             profiles_to_store.append(current_user)
+
+        if len(profiles_to_store) == 0:
+            logger.info("No profiles to store in vault")
+            return {"creates": None, "updates": None, "status": 202}
 
         # Store resulting user in the vault
         logger.info("Will store {} verified profiles".format(len(profiles_to_store)))

--- a/python-modules/cis_change_service/tests/test_profile.py
+++ b/python-modules/cis_change_service/tests/test_profile.py
@@ -195,7 +195,7 @@ class TestProfile(object):
         results = json.loads(result.get_data())
         print("result", results)
         assert results is not None
-        assert results.get("description") == "No operation occurred: {'creates': None, 'updates': None, 'status': 202}"
+        assert results.get("status_code") == 202
 
     @mock.patch("cis_change_service.idp.get_jwks")
     def test_post_new_profile_with_primary_username_should_fail(self, fake_jwks):

--- a/python-modules/cis_profile/cis_profile/profile.py
+++ b/python-modules/cis_profile/cis_profile/profile.py
@@ -159,7 +159,7 @@ class User(object):
             # This is where wee skip null/None attributes even if the original/current
             # user does not match (ie is not null)
             if level[attr].get("value") is not None or level[attr].get("values") is not None:
-                if _internal_level[attr] != level[attr]:
+                if _internal_level[attr].get("value") != level[attr].get("values"):
                     logger.debug("Merging in attribute {}".format(attr))
                     different_attrs.append(attr)
                     _internal_level[attr] = level[attr]

--- a/python-modules/cis_profile/cis_profile/profile.py
+++ b/python-modules/cis_profile/cis_profile/profile.py
@@ -159,7 +159,9 @@ class User(object):
             # This is where wee skip null/None attributes even if the original/current
             # user does not match (ie is not null)
             if level[attr].get("value") is not None or level[attr].get("values") is not None:
-                if _internal_level[attr].get("value") != level[attr].get("values"):
+                if (_internal_level[attr].get("value") != level[attr].get("value")) or (
+                    _internal_level[attr].get("values") != level[attr].get("values")
+                ):
                     logger.debug("Merging in attribute {}".format(attr))
                     different_attrs.append(attr)
                     _internal_level[attr] = level[attr]

--- a/python-modules/cis_profile/tests/test_profile.py
+++ b/python-modules/cis_profile/tests/test_profile.py
@@ -221,3 +221,10 @@ class TestProfile(object):
         u_orig.merge(u_patch)
         assert u_orig.as_dict()["access_information"]["ldap"]["values"] == {"test_replacement": None}
         assert u_orig.uuid.value == "31337"  # This has not changed because it was null/None in the patched profile
+
+    def test_merge_return_value(self):
+        a = profile.User(user_id="usera")
+        b = profile.User(user_id="userb")
+
+        res = a.merge(b)
+        assert "user_id" in res

--- a/python-modules/cis_publisher/cis_publisher/publisher.py
+++ b/python-modules/cis_publisher/cis_publisher/publisher.py
@@ -194,7 +194,11 @@ class Publish:
                     failed_users.put(identity)
                     break
             else:
-                logger.info("Profile successfully posted to API {}".format(profile.user_id.value))
+                logger.info(
+                    "Profile successfully posted to API {}, status_code: {}".format(
+                        profile.user_id.value, response.status_code
+                    )
+                )
 
     def _request_post(self, url, payload, headers):
         return requests.post(url, json=payload, headers=headers)


### PR DESCRIPTION
this adds logic to send back differences on a profile merge and decide what to do in certain cases
this means no notification for "no-update" data changes touching the vault, so less read backs (in addition to less writes)