### PR TITLE
fix delete notification

### DIFF
--- a/python-modules/cis_notifications/cis_notifications/event.py
+++ b/python-modules/cis_notifications/cis_notifications/event.py
@@ -43,7 +43,7 @@ class Event(object):
         if self.event.get("eventName") == "MODIFY":
             operation = "update"
 
-        if self.event.get("eventName") == "DELETE":
+        if self.event.get("eventName") == "REMOVE":
             operation = "delete"
 
         if updated_record is not None:


### PR DESCRIPTION
I'm getting `foxy` as operation. If I'm reading the doc (https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_Record.html) correctly this should fix it.

In general profiles are set to inactive before deleting them which triggers an update and DinoPark will discard all data of any inactive profile. However, when manually deleting profiles from the database this was causing profiles not being deleted.