### PR TITLE
Fix UnsupportedClassVersionError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+jdk: oraclejdk8
 dist: xenial
 python:
   - 3.7


### PR DESCRIPTION
Currently, this error is thrown

`Exception in thread "main" java.lang.UnsupportedClassVersionError: org/apache/logging/log4j/spi/ExtendedLogger : Unsupported major.minor version 52.0`

It looks like using Java 8 is the fix

https://stackoverflow.com/questions/40208309/travis-ci-build-failing-on-android-app-unsupported-major-minor-version-52