### PR TITLE
Fixes two issues with this query:

### DIFF
--- a/python-modules/cis_publisher/cis_publisher/auth0.py
+++ b/python-modules/cis_publisher/cis_publisher/auth0.py
@@ -226,11 +226,11 @@ class Auth0Publisher:
         # This can also be retrieved from /api/v2/connections
         # Ignore non-verified `email` (such as unfinished passwordless flows) as we don't consider these to be valid
         # users
-        max_date = datetime.utcnow() - timedelta(days=300)
+        max_date = datetime.utcnow() - timedelta(days=31)  # maximum login length + 1 day
         max_date_str = max_date.strftime("%Y-%m-%d")
         exclusion_query = (
-            f"logins_count:[2 TO *] AND NOT (last_login:[* TO {max_date_str}] AND "
-            '(groups:(everyone) OR NOT _exists_:"groups"))'
+            f"logins_count:[2 TO *] AND NOT last_login:[* TO {max_date_str}] AND "
+            '(groups:(everyone) OR (NOT _exists_:"groups"))'
         )
         az_query = exclusion_query + " AND email_verified:true AND ("
         t = ""


### PR DESCRIPTION
* The last_login query is too long, at 300 days. It only needs to be longer than the maximum login session duration.
* The way the groups query is constructed means that every user gets returned, regardless of the last_login date. This results in 40k users getting found, far more than necessary.