### PR TITLE
Configure CIS Test to trigger CIS to Auth0 webhook consumer Test

### DIFF
--- a/serverless-functions/webhook_notifier/serverless.yml
+++ b/serverless-functions/webhook_notifier/serverless.yml
@@ -39,7 +39,7 @@ custom:
     CIS_RP_URLS:
       production: https://people.mozilla.org/events/update,https://discourse-staging.itsre-apps.mozit.cloud/mozilla_iam/notification,https://discourse.mozilla.org/mozilla_iam/notification
       development: https://dinopark.k8s.dev.sso.allizom.org/events/update,https://auth0-cis-webhook-consumer.dev.sso.allizom.org/post
-      testing: https://dinopark.k8s.test.sso.allizom.org/events/update
+      testing: https://dinopark.k8s.test.sso.allizom.org/events/update,https://auth0-cis-webhook-consumer.test.sso.allizom.org/post
 provider:
   name: aws
   runtime: python3.8


### PR DESCRIPTION
Once this is merged, it should be tagged with a [tag that looks like this](https://github.com/mozilla-iam/cis/blob/d8d7499a9d61bc3d34238487f127244c54861e88/deploy.sh#L15) to initiate a deployment into the testing environment.

This should be done either at `?:22` or at `?:52` (22 minutes past the hour or 52 minutes past the hour) so that the deployment happens between two invocation storms that happen every 30 minutes.

Then watch the metrics of the invocations of this webhook to see if it's causing a problem (exhausting API call thresholds).

The addition of this webhook to the test environment will cause an additional
* invocation of this webhook
* call to the PersonAPI

for every ChangeAPI invocation.

The current invocation storms appear to trigger 4000 invocations of the Change API which means this will trigger an additional 8000 invocations (4000 webhook, 4000 PersonAPI)