### PR TITLE
enable deleting profiles on prod

### DIFF
--- a/python-modules/cis_change_service/cis_change_service/api.py
+++ b/python-modules/cis_change_service/cis_change_service/api.py
@@ -15,6 +15,7 @@ from cis_change_service import profile
 from cis_change_service.exceptions import IntegrationError
 from cis_change_service.exceptions import VerificationError
 from cis_change_service.idp import requires_auth
+from cis_change_service.idp import requires_scope
 from cis_change_service.idp import AuthError
 from cis_change_service import __version__
 
@@ -85,6 +86,7 @@ def version():
 @app.route("/v2/user", methods=["GET", "POST", "PUT", "DELETE"])
 @cross_origin(headers=["Content-Type", "Authorization"])
 @requires_auth
+@requires_scope("write")
 def change():
     connection = connect.AWS()
     connection.session()
@@ -119,6 +121,7 @@ def change():
 @app.route("/v2/users", methods=["GET", "POST", "PUT"])
 @cross_origin(headers=["Content-Type", "Authorization"])
 @requires_auth
+@requires_scope("write")
 def changes():
     connection = connect.AWS()
     connection.session()
@@ -134,6 +137,7 @@ def changes():
 
 @app.route("/v2/status", methods=["GET"])
 @cross_origin(headers=["Content-Type", "Authorization"])
+@requires_scope("write")
 def status():
     sequence_number = request.args.get("sequenceNumber")
     status = profile.Status(sequence_number)

--- a/python-modules/cis_change_service/cis_change_service/api.py
+++ b/python-modules/cis_change_service/cis_change_service/api.py
@@ -86,7 +86,6 @@ def version():
 @app.route("/v2/user", methods=["GET", "POST", "PUT", "DELETE"])
 @cross_origin(headers=["Content-Type", "Authorization"])
 @requires_auth
-@requires_scope("write")
 def change():
     connection = connect.AWS()
     connection.session()
@@ -121,7 +120,6 @@ def change():
 @app.route("/v2/users", methods=["GET", "POST", "PUT"])
 @cross_origin(headers=["Content-Type", "Authorization"])
 @requires_auth
-@requires_scope("write")
 def changes():
     connection = connect.AWS()
     connection.session()
@@ -137,7 +135,6 @@ def changes():
 
 @app.route("/v2/status", methods=["GET"])
 @cross_origin(headers=["Content-Type", "Authorization"])
-@requires_scope("write")
 def status():
     sequence_number = request.args.get("sequenceNumber")
     status = profile.Status(sequence_number)

--- a/serverless-functions/change/serverless.yml
+++ b/serverless-functions/change/serverless.yml
@@ -54,7 +54,7 @@ custom:
       development: change.api.dev.sso.allizom.org
       testing: change.api.test.sso.allizom.org
     CIS_ALLOW_DELETE:
-      production: false
+      production: true
       development: true
       testing: true
     CIS_DISCOVERY_URL:


### PR DESCRIPTION
Tired of deleting profiles directly in Dynamo.
Require _write_ scope for all change API endpoints.