### PR TITLE
Fix various missing test dependencies

### DIFF
--- a/python-modules/cis_notifications/setup.py
+++ b/python-modules/cis_notifications/setup.py
@@ -10,7 +10,7 @@ requirements = ["everett", "boto3", "configobj"]
 
 setup_requirements = ["pytest-runner", "setuptools>=40.5.0"]
 
-test_requirements = ["pytest", "pytest-watch", "pytest-cov", "patch", "mock", "flake8", "moto"]
+test_requirements = ["pytest", "pytest-watch", "pytest-cov", "patch", "mock", "flake8", "moto", "PyYAML"]
 
 extras = {"test": test_requirements}
 

--- a/python-modules/cis_postgresql/setup.py
+++ b/python-modules/cis_postgresql/setup.py
@@ -10,7 +10,7 @@ requirements = ["everett", "boto", "boto3", "botocore"]
 
 setup_requirements = ["pytest-runner", "setuptools>=40.5.0"]
 
-test_requirements = ["pytest", "pytest-watch", "pytest-cov", "patch", "mock", "flake8", "moto"]
+test_requirements = ["pytest", "pytest-watch", "pytest-cov", "patch", "mock", "flake8", "moto", "docker"]
 
 extras = {"test": test_requirements}
 

--- a/python-modules/cis_publisher/setup.py
+++ b/python-modules/cis_publisher/setup.py
@@ -10,7 +10,7 @@ requirements = ["boto3", "botocore", "everett", "everett[ini]", "auth0-python"]
 
 setup_requirements = ["pytest-runner"]
 
-test_requirements = ["pytest", "pytest-watch", "pytest-cov", "moto", "flake8"]
+test_requirements = ["pytest", "pytest-watch", "pytest-cov", "moto", "flake8", "mock"]
 
 extras = {"test": test_requirements}
 


### PR DESCRIPTION
Hi, reviewers.

I identified some missing dependencies for the setup.py "tests" phase, that need to be resolved in order for new CI to pass.

I've confirmed in #531 that new CI passes when these changes are incorporated.