### PR TITLE
ci: Disable builds for PRs due to Docker Hub creds

### DIFF
--- a/.github/workflows/make-test.yml
+++ b/.github/workflows/make-test.yml
@@ -1,6 +1,7 @@
 name: make-test
 
-on: [push, pull_request]
+# TODO: on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -12,6 +13,7 @@ jobs:
           # GitHub.com > (this repo) > Settings > Secrets
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          # TODO: find a way to avoid this or make it compatible with on: [pull_request]
       - name: Run make test
         run: |
           make test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CIS - Change Integration Service
-[![Build Status](https://travis-ci.org/mozilla-iam/cis.svg?branch=master)](https://travis-ci.org/mozilla-iam/cis)
+[![Build Status](https://github.com/mozilla-iam/cis/actions/workflows/make-test.yml/badge.svg)](https://github.com/mozilla-iam/cis/actions/)
 CIS is the Mozilla IAM Change Integration Service.
 
 ## I'm an API user, where do I start?
@@ -11,6 +11,11 @@ See [PersonAPI](docs/PersonAPI.md) docs for querying the API.
 * Docker
 * Docker-Compose
 * Make
+
+### Continuous Integration
+
+* GitHub Actions (fork the repository on GitHub to begin)
+* Docker Hub API key (access level public-readonly)
 
 ## Build & Deploy (manual)
 
@@ -79,7 +84,7 @@ $ make test-tox
 - well-known-endpoint contains the Mozilla IAM Well Known endpoint data and it's deployment methods (this endpoint can
   only be manually deployed)
 - buildspec.yml contains the AWS Codebuild CD scripts.
-- .travis.yml contains the Travis CI scripts.
+- .github/workflows/make-test.yml contains the GitHub Actions CI script.
 
 Note that many directories contain their own README.md, which has more detailed information.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ See [PersonAPI](docs/PersonAPI.md) docs for querying the API.
 
 * GitHub Actions (fork the repository on GitHub to begin)
 * Docker Hub API key (access level public-readonly)
+  * CI only runs on PRs from branches pushed to mozilla-cis/iam.
 
 ## Build & Deploy (manual)
 


### PR DESCRIPTION
My straightforward Travis-to-GitHub-Actions conversion has a flaw, requiring Docker Hub public credentials to avoid rate-limiting.  There are ways to do this safely, but they're not done yet; so for now, disabling builds on pull requests from other repos. The symptom of this issue is that builds fail due to empty/null DOCKER_HUB_xyz variables, as seen in make-test.yml.

Pushing to mozilla-iam/cis:branch rather than yourhome/cis:branch will allow CI to run while this is the case.

Includes and closes #535, which updates the README to reference GitHub Actions rather than Travis CI, and documents the Docker Hub dependency and the restriction.