### PR TITLE
Remove trailing whitespace from a variety of files

### DIFF
--- a/cloudformation/development-secret-policy.yml
+++ b/cloudformation/development-secret-policy.yml
@@ -3,12 +3,12 @@ Description: Create a managed policy to bind to roles that allows secret access 
 Resources:
   SecretAccess:
     Type: AWS::IAM::ManagedPolicy
-    Properties: 
+    Properties:
       Description: Allows retrieval of secrets in the cis_development namespace.
       Path: '/'
-      PolicyDocument: 
+      PolicyDocument:
         Version: "2012-10-17"
-        Statement: 
+        Statement:
           - Effect: Allow
             Action:
               - "ssm:GetParameterHistory"

--- a/python-modules/cis_identity_vault/Makefile
+++ b/python-modules/cis_identity_vault/Makefile
@@ -22,7 +22,7 @@ venv:
 	echo "source venv/bin/activate"
 
 .install-test:
-		pip install .[test]	
+		pip install .[test]
 		npm install kinesalite
 		touch $@
 

--- a/serverless-functions/postgres_access_layer/serverless.yml
+++ b/serverless-functions/postgres_access_layer/serverless.yml
@@ -126,7 +126,7 @@ functions:
           - sg-015971fe39add456e
     handler: handler.handle
     events:
-      - stream: 
+      - stream:
           arn: ${self:custom.postgresqlAccessLayerEnvironment.CIS_DYNAMODB_STREAM_ARN.${self:custom.postgresqlAccessLayerStage}}
           batchSize: 1000
           startingPosition: LATEST

--- a/serverless-functions/postgresql_replicator/serverless.yml
+++ b/serverless-functions/postgresql_replicator/serverless.yml
@@ -126,7 +126,7 @@ functions:
           - sg-015971fe39add456e
     handler: handler.handle
     events:
-      - stream: 
+      - stream:
           arn: ${self:custom.postgresqlReplicatorEnvironment.CIS_DYNAMODB_STREAM_ARN.${self:custom.postgresqlReplicatorStage}}
           batchSize: 1000
           startingPosition: LATEST

--- a/serverless-functions/webhook_notifier/serverless.yml
+++ b/serverless-functions/webhook_notifier/serverless.yml
@@ -51,7 +51,7 @@ provider:
     CIS_API_IDENTIFIER: ${self:custom.webhookEnvironment.IDENTIFIER.${self:custom.webhookStage}}
     CIS_AUTHZERO_TENANT: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}}
     CIS_RP_URLS: ${self:custom.webhookEnvironment.CIS_RP_URLS.${self:custom.webhookStage}}
-    WEBHOOK_NOTIFICATIONS_AUTH0_DOMAIN: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}} 
+    WEBHOOK_NOTIFICATIONS_AUTH0_DOMAIN: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}}
     CIS_SECRET_MANAGER_SSM_PATH: ${self:custom.webhookEnvironment.CIS_SECRET_MANAGER_SSM_PATH.${self:custom.webhookStage}}
   iamRoleStatements:
     - Effect: "Allow" # xray permissions (required)
@@ -99,7 +99,7 @@ functions:
     memorySize: 512
     timeout: 120
     events:
-      - stream: 
+      - stream:
           arn: ${self:custom.webhookEnvironment.CIS_DYNAMODB_STREAM_ARN.${self:custom.webhookStage}}
           batchSize: 100
           startingPosition: LATEST


### PR DESCRIPTION
#528 included fixes for trailing whitespace in a variety of files, which I imagine we should fix regardless of #528 itself. These don't seem to be caught by CI, so this probably will not need to be merged into the CI PR I'm expecting to end up creating out of several other PRs.

Reviewers, my biggest concern is that this ought to be a no-op, but if it will trigger lambda autodeploys or other unknown things, then that would be of concern.

Replaces #532.