### PR TITLE
ci: Remove -j# from test options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ push-ci-container:
 .PHONY: test
 test:
 	docker-compose build
-	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules -j$(nproc) test-tox'
+	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules test-tox'
 
 .PHONE: test-module
 test-module:
 	docker-compose build
 	@echo "Testing single module: $(MODULE)"
-	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules/$(MODULE) -j$(nproc) test-tox'
+	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules/$(MODULE) test-tox'
 
 .PHONY: developer-shell
 developer-shell:


### PR DESCRIPTION
We have what looks to be [a CI failure](https://github.com/mozilla-iam/cis/pull/537/checks?check_run_id=3175469630) due to a race condition between two different sets of tests that expect to be using a given port number, so this patch removes all parallelization from the tests (which is how I kept them for most of my repairs anyways). HT @gcoxmoz