### PR TITLE
IAM-1427, pylint + softly accept miscased user emails in HRIS publisher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,13 +77,13 @@ push-ci-container:
 .PHONY: test
 test:
 	docker-compose build
-	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules -j$(nproc) test-tox'
+	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules test-tox'
 
 .PHONE: test-module
 test-module:
 	docker-compose build
 	@echo "Testing single module: $(MODULE)"
-	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules/$(MODULE) -j$(nproc) test-tox'
+	docker-compose run --rm tester bash -c '/root/utils/fake-creds.sh && source /root/.bashrc && make -C python-modules/$(MODULE) test-tox'
 
 .PHONY: developer-shell
 developer-shell:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="akrug@mozilla.com"
 # skip global package update - whatever archlinux/latest has is enough
 #RUN pacman -Syyu --noconfirm
 # install arch base-devel, dependencies, and refresh the package list from upstream
-RUN pacman --noconfirm -S -y --needed base-devel iputils net-tools grep nodejs npm docker make pacman-contrib jq python-pip zip gcc python2 wget unzip tar gawk jdk-openjdk
+RUN pacman --noconfirm -S -y --needed base-devel iputils net-tools grep nodejs npm docker make pacman-contrib jq python-pip zip gcc python2 wget unzip tar gawk jdk-openjdk postgresql-libs python-psycopg2
 ## Use this if you need to force-downgrade system's python
 ## You'll want to compile the version you want first and upload it to S3
 # RUN wget https://s3-us-west-2.amazonaws.com/public.iam.mozilla.com/python37-3.7.5-2-x86_64.pkg.tar.xz

--- a/python-modules/cis_aws/tests/test_connect.py
+++ b/python-modules/cis_aws/tests/test_connect.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 
 class TestConnect(object):
     def setup(self):
-        self.dynalite_port = str(random.randint(32000, 34000))
-        self.kinesalite_port = str(random.randint(32000, 34000))
+        self.dynalite_port = str(random.randint(32000, 32100))
+        self.kinesalite_port = str(random.randint(32100, 32200))
         os.environ["CIS_DYNALITE_PORT"] = self.dynalite_port
         os.environ["CIS_KINESALITE_PORT"] = self.kinesalite_port
         self.dynalite_host = "localhost"

--- a/python-modules/cis_change_service/tests/test_api.py
+++ b/python-modules/cis_change_service/tests/test_api.py
@@ -72,7 +72,7 @@ def ensure_appropriate_publishers_and_sign(fake_profile, publisher_rules, condit
 
 class TestAPI(object):
     def setup(self):
-        self.dynalite_port = str(random.randint(32000, 34000))
+        self.dynalite_port = str(random.randint(32200, 32300))
         os.environ["CIS_CONFIG_INI"] = "tests/mozilla-cis.ini"
         os.environ["AWS_XRAY_SDK_ENABLED"] = "false"
         os.environ["CIS_ENVIRONMENT"] = "local"
@@ -87,7 +87,7 @@ class TestAPI(object):
         self.mock_salt = self.patcher_salt.start()
 
         config = get_config()
-        os.environ["CIS_DYNALITE_PORT"] = str(random.randint(32000, 34000))
+        os.environ["CIS_DYNALITE_PORT"] = str(random.randint(32300, 32400))
         self.dynalite_port = config("dynalite_port", namespace="cis")
         self.dynaliteprocess = subprocess.Popen(
             [

--- a/python-modules/cis_change_service/tests/test_profile.py
+++ b/python-modules/cis_change_service/tests/test_profile.py
@@ -28,7 +28,7 @@ class TestProfile(object):
         os.environ["AWS_XRAY_SDK_ENABLED"] = "false"
         os.environ["CIS_ENVIRONMENT"] = "local"
         os.environ["CIS_CONFIG_INI"] = "tests/mozilla-cis.ini"
-        self.dynalite_port = str(random.randint(32000, 34000))
+        self.dynalite_port = str(random.randint(32400, 32500))
         os.environ["CIS_DYNALITE_PORT"] = self.dynalite_port
         self.dynaliteprocess = subprocess.Popen(
             [

--- a/python-modules/cis_identity_vault/setup.py
+++ b/python-modules/cis_identity_vault/setup.py
@@ -32,6 +32,8 @@ test_requirements = [
     "moto>=1.3.7",
     "flake8",
     "pytest-benchmark",
+    "psycopg2",
+    "psycopg2-binary",
 ]
 
 extras = {"test": test_requirements}

--- a/python-modules/cis_identity_vault/tests/test_rds.py
+++ b/python-modules/cis_identity_vault/tests/test_rds.py
@@ -5,7 +5,7 @@ from cis_profile import FakeUser
 
 @mock_ssm
 class TestRDS(object):
-    def setup(self):
+    def setup(self, *args):
         os.environ["CIS_ENVIRONMENT"] = "testing"
         os.environ["CIS_REGION_NAME"] = "us-east-1"
         os.environ["DEFAULT_AWS_REGION"] = "us-east-1"

--- a/python-modules/cis_identity_vault/tests/test_user_model.py
+++ b/python-modules/cis_identity_vault/tests/test_user_model.py
@@ -17,7 +17,7 @@ logging.basicConfig(format=FORMAT)
 
 @mock_dynamodb2
 class TestUsersDynalite(object):
-    def setup(self):
+    def setup(self, *args):
         os.environ["CIS_ENVIRONMENT"] = "purple"
         os.environ["CIS_REGION_NAME"] = "us-east-1"
         os.environ["DEFAULT_AWS_REGION"] = "us-east-1"

--- a/python-modules/cis_identity_vault/tests/test_vault.py
+++ b/python-modules/cis_identity_vault/tests/test_vault.py
@@ -22,7 +22,7 @@ class TestVault(object):
 
 class TestVaultDynalite(object):
     def setup_class(self):
-        self.dynalite_port = str(random.randint(32000, 34000))
+        self.dynalite_port = str(random.randint(32500, 32600))
         os.environ["CIS_DYNALITE_PORT"] = self.dynalite_port
         self.dynaliteprocess = subprocess.Popen(
             [

--- a/python-modules/cis_identity_vault/tox.ini
+++ b/python-modules/cis_identity_vault/tox.ini
@@ -15,5 +15,7 @@ deps=
   tox-run-before
   ../cis_profile
   ../cis_crypto
-  /psycopg2-2.8.3
-commands=pytest tests/ --cov=cis_identity_vault {posargs}
+
+commands = 
+  pip install psycopg2 psycopg2-binary
+  pytest tests/ --cov=cis_identity_vault {posargs}

--- a/python-modules/cis_postgresql/setup.py
+++ b/python-modules/cis_postgresql/setup.py
@@ -10,7 +10,18 @@ requirements = ["everett", "boto", "boto3", "botocore"]
 
 setup_requirements = ["pytest-runner", "setuptools>=40.5.0"]
 
-test_requirements = ["pytest", "pytest-watch", "pytest-cov", "patch", "mock", "flake8", "moto", "docker"]
+test_requirements = [
+    "pytest",
+    "pytest-watch",
+    "pytest-cov",
+    "patch",
+    "mock",
+    "flake8",
+    "moto",
+    "docker",
+    "psycopg2",
+    "psycopg2-binary",
+]
 
 extras = {"test": test_requirements}
 

--- a/python-modules/cis_postgresql/tests/test_handler.py
+++ b/python-modules/cis_postgresql/tests/test_handler.py
@@ -65,7 +65,7 @@ class EventGenerator(object):
 
 @mock_dynamodb2
 class TestEventHandler(object):
-    def setup(self):
+    def setup(self, *args):
         fh = open("tests/fixture/dynamodb-event.json")
         # Event data structure to load in order to mock a profile update
         self.event_json = fh.read()

--- a/python-modules/cis_postgresql/tox.ini
+++ b/python-modules/cis_postgresql/tox.ini
@@ -17,6 +17,7 @@ deps=
   ../cis_identity_vault
   ../cis_profile
   ../cis_crypto
-  /psycopg2-2.8.3
 
-commands=pytest tests/ --cov=cis_postgresql {posargs}
+commands = 
+  pip install psycopg2 psycopg2-binary
+  pytest tests/ --cov=cis_postgresql {posargs}

--- a/python-modules/cis_processor/tests/test_operation.py
+++ b/python-modules/cis_processor/tests/test_operation.py
@@ -57,7 +57,7 @@ def kinesis_event_generate(user_profile):
 
 @mock_dynamodb2
 class TestOperation(object):
-    def setup(self):
+    def setup(self, *args):
         os.environ["CIS_CONFIG_INI"] = "tests/fixture/mozilla-cis.ini"
         self.config = get_config()
         from cis_profile import WellKnown

--- a/python-modules/cis_processor/tests/test_profile_delegate.py
+++ b/python-modules/cis_processor/tests/test_profile_delegate.py
@@ -36,7 +36,7 @@ def kinesis_event_generate(user_profile):
 
 @mock_dynamodb2
 class TestProfileDelegate(object):
-    def setup(self):
+    def setup(self, *args):
         os.environ["CIS_CONFIG_INI"] = "tests/fixture/mozilla-cis.ini"
         self.dynamodb_client = boto3.client(
             "dynamodb", region_name="us-west-2", aws_access_key_id="ak", aws_secret_access_key="sk"

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/advanced.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/advanced.py
@@ -96,21 +96,21 @@ class v2UsersByAttrContains(Resource):
     decorators = [requires_auth]
 
     def get(self):
-        parser = reqparse.RequestParser()
+        parser = reqparse.RequestParser(bundle_errors=True)
         parser.add_argument("Authorization", location="headers")
-        parser.add_argument("filterDisplay", type=str)
+        parser.add_argument("filterDisplay", type=str, location="args")
 
         for attr in allowed_advanced_queries:
             # Ensure that only our allowed attributes are parsed.
-            parser.add_argument(attr, type=allowed_advanced_queries[attr])
+            parser.add_argument(attr, type=allowed_advanced_queries[attr], location="args")
 
         for attr in allowed_advanced_queries:
             # Ensure that only our allowed attributes as inverse ops are parsed.
-            parser.add_argument(f"not_{attr}", type=allowed_advanced_queries[attr])
+            parser.add_argument(f"not_{attr}", type=allowed_advanced_queries[attr], location="args")
 
-        parser.add_argument("active", type=bool)
-        parser.add_argument("fullProfiles", type=bool)
-        parser.add_argument("nextPage", type=str)
+        parser.add_argument("active", type=bool, location="args")
+        parser.add_argument("fullProfiles", type=bool, location="args")
+        parser.add_argument("nextPage", type=str, location="args")
 
         # determine which arg was passed in from the whitelist and then set it up
         reserved_keys = ["active", "nextPage", "fullProfiles", "Authorization", "filterDisplay"]

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
@@ -156,9 +156,9 @@ class v2UsersByAny(Resource):
 
     def get(self):
         parser = reqparse.RequestParser()
-        parser.add_argument("connectionMethod", type=str)
-        parser.add_argument("active", type=str)
-        parser.add_argument("nextPage", type=str)
+        parser.add_argument("connectionMethod", type=str, location="args")
+        parser.add_argument("active", type=str, location="args")
+        parser.add_argument("nextPage", type=str, location="args")
 
         args = parser.parse_args()
 
@@ -213,8 +213,8 @@ def getUser(id, find_by):
     id = urllib.parse.unquote(id)
     parser = reqparse.RequestParser()
     parser.add_argument("Authorization", location="headers")
-    parser.add_argument("filterDisplay", type=str)
-    parser.add_argument("active", type=str)
+    parser.add_argument("filterDisplay", type=str, location="args")
+    parser.add_argument("active", type=str, location="args")
     args = parser.parse_args()
     scopes = get_scopes(args.get("Authorization"))
     filter_display = args.get("filterDisplay", None)
@@ -276,10 +276,10 @@ class v2Users(Resource):
         """Return a single user with id `user_id`."""
         parser = reqparse.RequestParser()
         parser.add_argument("Authorization", location="headers")
-        parser.add_argument("nextPage", type=str)
-        parser.add_argument("primaryEmail", type=str)
-        parser.add_argument("filterDisplay", type=str)
-        parser.add_argument("active", type=str)
+        parser.add_argument("nextPage", type=str, location="args")
+        parser.add_argument("primaryEmail", type=str, location="args")
+        parser.add_argument("filterDisplay", type=str, location="args")
+        parser.add_argument("active", type=str, location="args")
 
         args = parser.parse_args()
 

--- a/serverless-functions/webhook_notifier/serverless.yml
+++ b/serverless-functions/webhook_notifier/serverless.yml
@@ -37,7 +37,7 @@ custom:
       development: https://dinopark.dev.k8s.sso.allizom.org/beta/
       testing: https://dinopark.test.k8s.sso.allizom.org/beta/
     CIS_RP_URLS:
-      production: https://people.mozilla.org/events/update,https://discourse-staging.itsre-apps.mozit.cloud/mozilla_iam/notification,https://discourse.mozilla.org/mozilla_iam/notification,https://auth0-cis-webhook-consumer.sso.mozilla.com/post
+      production: https://people.mozilla.org/events/update,https://discourse-staging.itsre-apps.mozit.cloud/mozilla_iam/notification,https://discourse.mozilla.org/mozilla_iam/notification,https://auth0-cis-webhook-consumer.sso.mozilla.com/post,https://bugzilla.mozilla.org/mozillaiam/user/update,https://bugzilla-dev.allizom.org/mozillaiam/user/update
       development: https://dinopark.k8s.dev.sso.allizom.org/events/update,https://auth0-cis-webhook-consumer.dev.sso.allizom.org/post
       testing: https://dinopark.k8s.test.sso.allizom.org/events/update,https://auth0-cis-webhook-consumer.test.sso.allizom.org/post
 provider:
@@ -51,7 +51,7 @@ provider:
     CIS_API_IDENTIFIER: ${self:custom.webhookEnvironment.IDENTIFIER.${self:custom.webhookStage}}
     CIS_AUTHZERO_TENANT: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}}
     CIS_RP_URLS: ${self:custom.webhookEnvironment.CIS_RP_URLS.${self:custom.webhookStage}}
-    WEBHOOK_NOTIFICATIONS_AUTH0_DOMAIN: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}} 
+    WEBHOOK_NOTIFICATIONS_AUTH0_DOMAIN: ${self:custom.webhookEnvironment.WEBHOOK_NOTIFICATION_AUTH0_DOMAIN.${self:custom.webhookStage}}
     CIS_SECRET_MANAGER_SSM_PATH: ${self:custom.webhookEnvironment.CIS_SECRET_MANAGER_SSM_PATH.${self:custom.webhookStage}}
   iamRoleStatements:
     - Effect: "Allow" # xray permissions (required)
@@ -99,7 +99,7 @@ functions:
     memorySize: 512
     timeout: 120
     events:
-      - stream: 
+      - stream:
           arn: ${self:custom.webhookEnvironment.CIS_DYNAMODB_STREAM_ARN.${self:custom.webhookStage}}
           batchSize: 100
           startingPosition: LATEST


### PR DESCRIPTION
2 commits, easier to understand if you examine individually.
commit 1 is pylint inspired cleanup of logging and ordering of imports.
commit 2 is "if you can't match on emails from the workday report, try again with lowercase.  If THAT works, use it but emit a warning; if not, fail like you have been doing."