### PR TITLE
person/change Custom domains are managed elsewhere

### DIFF
--- a/serverless-functions/change/package.json
+++ b/serverless-functions/change/package.json
@@ -10,7 +10,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serverless-domain-manager": "^2.6.13",
     "serverless-plugin-tracing": "^2.0.0"
   }
 }

--- a/serverless-functions/change/serverless.yml
+++ b/serverless-functions/change/serverless.yml
@@ -1,6 +1,5 @@
 service: change-service
 plugins:
-  - serverless-domain-manager
   - serverless-plugin-tracing
 custom:
   changeStage: ${opt:stage, self:provider.stage}
@@ -65,13 +64,6 @@ custom:
       production: publisher
       development: publisher
       testing: publisher
-  customDomain:
-    domainName: ${self:custom.changeEnvironment.DOMAIN_NAME.${self:custom.changeStage}}
-    basePath: ''
-    stage: ${self:custom.changeStage}
-    endpointType: edge
-    createRoute53Record: true
-    certificateName: ${self:custom.changeEnvironment.DOMAIN_NAME.${self:custom.changeStage}}
 provider:
   name: aws
   runtime: python3.8

--- a/serverless-functions/profile_retrieval/package.json
+++ b/serverless-functions/profile_retrieval/package.json
@@ -12,7 +12,6 @@
   "dependencies": {},
   "devDependencies": {
     "serverless-api-stage": "^1.4.0",
-    "serverless-domain-manager": "^2.6.13",
     "serverless-plugin-tracing": "^2.0.0"
   }
 }

--- a/serverless-functions/profile_retrieval/serverless.yml
+++ b/serverless-functions/profile_retrieval/serverless.yml
@@ -1,6 +1,5 @@
 service: profile-retrieval
 plugins:
-  - serverless-domain-manager
   - serverless-plugin-tracing
 custom:
   profileRetrievalStage: ${opt:stage, self:provider.stage}
@@ -37,13 +36,6 @@ custom:
       production: https://auth.mozilla.com/.well-known/mozilla-iam
       development: https://auth.allizom.org/.well-known/mozilla-iam
       testing: https://auth.mozilla.com/.well-known/mozilla-iam
-  customDomain:
-    domainName: ${self:custom.profileRetrievalEnvironment.DOMAIN_NAME.${self:custom.profileRetrievalStage}}
-    basePath: ''
-    stage: ${self:custom.profileRetrievalStage}
-    endpointType: edge
-    createRoute53Record: true
-    certificateName: ${self:custom.profileRetrievalEnvironment.DOMAIN_NAME.${self:custom.profileRetrievalStage}}
 provider:
   name: aws
   runtime: python3.8


### PR DESCRIPTION
Now that we're onboarding to Fastly WAF, this custom domain configuration will need to be moved elsewhere.

For now, they're "clickops"'d to point to the Fastly endpoint, for lack of a better place.

Previous records are:

    person.api.dev.sso.allizom.org CNAME dkvp8o2j3an0s.cloudfront.net
    change.api.dev.sso.allizom.org CNAME dnvuz7rflzcix.cloudfront.net

    person.api.test.sso.allizom.org CNAME d1xhywfw7lzv8t.cloudfront.net
    change.api.test.sso.allizom.org CNAME dqogv2ah2qsgb.cloudfront.net

Prod isn't set up quite yet, but for completion, the records are:

    person.api.sso.mozilla.com CNAME d2ot71lo28jdym.cloudfront.net
    change.api.sso.mozilla.com CNAME d1dx0nvrqzhzid.cloudfront.net

These were all updated to be `CNAME mozilla.map.fastly.net`.

Jira: [IAM-1629](https://mozilla-hub.atlassian.net/browse/IAM-1629), [OPST-1768](https://mozilla-hub.atlassian.net/browse/OPST-1768)