### PR TITLE
build Disable AWS Codebuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,4 +7,4 @@ phases:
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
   build:
     commands:
-      - bash deploy.sh
+      - echo bash deploy.sh


### PR DESCRIPTION
We're using a serverless version which doesn't support Python 3.9.

    Serverless:   at 'provider.runtime': should be equal to one of the allowed
    values [dotnetcore2.1, dotnetcore3.1, go1.x, java11, java8, java8.al2,
    nodejs10.x, nodejs12.x, provided, provided.al2, python2.7, python3.6,
    python3.7, python3.8, ruby2.5, ruby2.7]

The latest version it supports is EOL by AWS (and Python!).

Jira: [IAM-1677](https://mozilla-hub.atlassian.net/browse/IAM-1677)