### PR TITLE
We're not returning results fast enough

### DIFF
--- a/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
@@ -53,8 +53,8 @@ def scan(
     logger.debug("Creating new threads and queue.")
     result_queue = queue.Queue()
 
-    pool_size = 10
-    max_segments = 10
+    pool_size = 16
+    max_segments = 16
 
     users = []
     last_evaluated_key = None


### PR DESCRIPTION
The HRIS sync job is currently failing because the `v2UsersByAny` endpoint is taking too long to return results. This change bumps the number of segments we use when scanning Dynamo, in an attempt to finish the work _a little bit sooner_.

Jira: [IAM-1668](https://mozilla-hub.atlassian.net/browse/IAM-1668)