### PR TITLE
Add dax

### DIFF
--- a/dev/mise-mac-helper.sh
+++ b/dev/mise-mac-helper.sh
@@ -13,4 +13,4 @@ export LDFLAGS="${LDFLAGS:-} -L/opt/homebrew/opt/openssl@1.1/lib"
 
 # Assumes the user has run:
 # brew install libpq
-export PATH="$PATH:/opt/homebrew/opt/libpq/bin"
+export PATH="/opt/homebrew/opt/libpq/bin:$PATH"

--- a/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
@@ -24,6 +24,8 @@ def get_segment(
     )
 
     if projection_expression:
+        scan_kwargs["ProjectionExpression"] = projection_expression
+    else:
         scan_kwargs["ProjectionExpression"] = "id, primary_email, user_uuid, active"
 
     if exclusive_start_key:

--- a/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
@@ -90,10 +90,9 @@ def scan(
     while not result_queue.empty():
         logger.debug("Results queue is not empty.")
         result = result_queue.get()
-
-        if result is not None:
-            users.extend(result.get("users"))
-
+        # A consequence of using DAX is that sometimes we receive a `None`.
+        users_additional = result.get("users") or []
+        users.extend(users_additional)
         if result.get("segment") == max_segments - 1:
             logger.debug("This is the last segment.")
             last_evaluated_key = result.get("nextPage")

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/common.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/common.py
@@ -4,6 +4,7 @@ import orjson
 import logging
 import os
 import re
+from amazondax import AmazonDaxClient
 from botocore.stub import Stubber
 from everett.ext.inifile import ConfigIniEnv
 from everett.manager import ConfigManager
@@ -62,6 +63,16 @@ def get_dynamodb_client():
         session = boto3.session.Session(region_name=region)
         client = session.client("dynamodb", config=client_config)
 
+    return client
+
+
+def get_dax_client():
+    region = config("dynamodb_region", namespace="cis", default="us-west-2")
+    environment = config("environment", namespace="cis", default="local")
+    dax_endpoint_url = config("dax_endpoint_url", namespace="cis", default="deadbeef")
+    client_config = botocore.config.Config(max_pool_connections=50)
+    session = boto3.session.Session(region_name=region)
+    client = AmazonDaxClient(session._session, endpoint_url=dax_endpoint_url)
     return client
 
 

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/idp.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/idp.py
@@ -1,10 +1,9 @@
-import json
 import logging
+import requests
 
 from functools import wraps
 from flask import request
 from flask import _request_ctx_stack
-from six.moves.urllib.request import urlopen
 from jose import jwt
 
 from cis_profile_retrieval_service.common import get_config
@@ -44,10 +43,7 @@ def get_token_auth_header():
 
 
 def get_jwks():
-    # XXX TBD do this with request purely instead of six
-    jsonurl = urlopen("https://" + AUTH0_DOMAIN + "/.well-known/jwks.json")
-    jwks = json.loads(jsonurl.read())
-    return jwks
+    return requests.get(f"https://{AUTH0_DOMAIN}/.well-known/jwks.json").json()
 
 
 def requires_auth(f):

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
@@ -19,6 +19,7 @@ from cis_profile.profile import User
 from cis_profile_retrieval_service.advanced import v2UsersByAttrContains
 from cis_profile_retrieval_service.common import get_config
 from cis_profile_retrieval_service.common import initialize_vault
+from cis_profile_retrieval_service.common import get_dax_client
 from cis_profile_retrieval_service.common import get_dynamodb_client
 from cis_profile_retrieval_service.common import get_table_resource
 from cis_profile_retrieval_service.common import load_dirty_json
@@ -71,6 +72,7 @@ if config("initialize_vault", namespace="person_api", default="false") == "true"
 
 authorization_middleware = AuthorizationMiddleware()
 dynamodb_table = get_table_resource()
+dax_client = get_dax_client()
 dynamodb_client = get_dynamodb_client()
 transactions = config("transactions", namespace="cis", default="false")
 
@@ -159,6 +161,7 @@ class v2UsersByAny(Resource):
         parser.add_argument("connectionMethod", type=str, location="args")
         parser.add_argument("active", type=str, location="args")
         parser.add_argument("nextPage", type=str, location="args")
+        parser.add_argument("cached", type=str, location="args")
 
         args = parser.parse_args()
 
@@ -169,8 +172,16 @@ class v2UsersByAny(Resource):
         if next_page is not None:
             next_page = urllib.parse.unquote(next_page)
 
+        cached = args.get("cached", "false") == "true"
+        if cached:
+            db_client = dax_client
+        else:
+            db_client = dynamodb_client
+
         if transactions == "false":
-            identity_vault = user.Profile(dynamodb_table, dynamodb_client, transactions=False)
+            if cached:
+                logger.info("Using dax client")
+            identity_vault = user.Profile(dynamodb_table, db_client, transactions=False)
         elif transactions == "true":
             identity_vault = user.Profile(dynamodb_table, dynamodb_client, transactions=True)
 

--- a/python-modules/cis_profile_retrieval_service/setup.py
+++ b/python-modules/cis_profile_retrieval_service/setup.py
@@ -23,6 +23,7 @@ requirements = [
     "flask-graphql",
     "requests",
     "aniso8601",
+    "amazon-dax-client",
     "aws-xray-sdk",
 ]
 

--- a/requirements/core.txt
+++ b/requirements/core.txt
@@ -1,12 +1,12 @@
 # From the cis_production lambda layer.
 aniso8601==7.0.0
+antlr4-python3-runtime==4.7.2
 async_generator==1.10
 attrs==20.2.0
 auth0_python==3.13.0
 aws_xray_sdk==2.6.0
-boto==2.49.0
-boto3==1.15.7
-botocore==1.18.7
+boto3==1.17.112
+botocore==1.20.112
 certifi==2020.6.20
 cffi==1.14.3
 chardet==3.0.4
@@ -47,7 +47,7 @@ pytz==2020.1
 requests==2.32.4
 rsa==4.6
 Rx==1.6.1
-s3transfer==0.3.3
+s3transfer==0.4.2
 serverless_wsgi==1.7.5
 setuptools==50.3.0
 six==1.15.0
@@ -62,3 +62,4 @@ typing_extensions==4.14.0
 urllib3==1.25.10
 Werkzeug==1.0.1
 zipp==3.2.0
+amazon-dax-client==2.0.3

--- a/serverless-functions/profile_retrieval/networking.development.yml
+++ b/serverless-functions/profile_retrieval/networking.development.yml
@@ -1,0 +1,6 @@
+security_groups:
+  - sg-0f3fe65edcb2c3228
+subnets:
+  - subnet-043a0c0c3ca174f89
+  - subnet-0db4c24a0a42e5de3
+  - subnet-08bf6671abe222b21

--- a/serverless-functions/profile_retrieval/serverless.yml
+++ b/serverless-functions/profile_retrieval/serverless.yml
@@ -14,10 +14,16 @@ custom:
       production: api.sso.mozilla.com
       development: api.dev.sso.allizom.org
       testing: api.test.sso.allizom.org
+    CIS_DAX_ARN:
+      production: arn:aws:dax:us-west-2:320464205386:cache/production-id
+      development: arn:aws:dax:us-west-2:320464205386:cache/development-id
+      testing: arn:aws:dax:us-west-2:320464205386:cache/testing-id
     CIS_DYNAMODB_ARN:
       production: arn:aws:dynamodb:us-west-2:320464205386:table/production-identity-vault
       development: arn:aws:dynamodb:us-west-2:320464205386:table/development-identity-vault
       testing: arn:aws:dynamodb:us-west-2:320464205386:table/testing-identity-vault
+    CIS_DAX_ENDPOINT_URL:
+      development: daxs://development-id.fmov7e.dax-clusters.us-west-2.amazonaws.com
     PERSON_API_AUTH0_DOMAIN:
       production: auth.mozilla.auth0.com
       development: auth.mozilla.auth0.com
@@ -54,6 +60,8 @@ provider:
     # way.
     timeoutInMillis: 180000
   environment:
+    CIS_DAX_ARN: ${self:custom.profileRetrievalEnvironment.CIS_DAX_ARN.${self:custom.profileRetrievalStage}}
+    CIS_DAX_ENDPOINT_URL: ${self:custom.profileRetrievalEnvironment.CIS_DAX_ENDPOINT_URL.${self:custom.profileRetrievalStage}}
     CIS_DYNAMODB_ARN: ${self:custom.profileRetrievalEnvironment.CIS_DYNAMODB_ARN.${self:custom.profileRetrievalStage}}
     CIS_ENVIRONMENT: ${self:custom.profileRetrievalEnvironment.CIS_ENVIRONMENT.${self:custom.profileRetrievalStage}}
     CIS_ASSUME_ROLE_ARN: None
@@ -80,6 +88,15 @@ provider:
         - ${self:custom.profileRetrievalEnvironment.CIS_DYNAMODB_ARN.${self:custom.profileRetrievalStage}}
     - Effect: Allow
       Action:
+        - "dax:DescribeTable"
+        - "dax:Query"
+        - "dax:Scan"
+        - "dax:GetItem"
+      Resource:
+        - ${self:custom.profileRetrievalEnvironment.CIS_DAX_ARN.${self:custom.profileRetrievalStage}}/*
+        - ${self:custom.profileRetrievalEnvironment.CIS_DAX_ARN.${self:custom.profileRetrievalStage}}
+    - Effect: Allow
+      Action:
         - logs:CreateLogGroup
         - logs:CreateLogStream
         - logs:PutLogEvents
@@ -99,4 +116,7 @@ functions:
       - http: ANY /
       - http: ANY {proxy+}
     layers:
-      -  ${ssm:/iam/cis/${self:custom.profileRetrievalStage}/build/lambda_layer_arn}
+      - ${ssm:/iam/cis/${self:custom.profileRetrievalStage}/build/lambda_layer_arn}
+    vpc:
+      securityGroupIds: ${file(./networking.${self:custom.profileRetrievalStage}.yml):security_groups}
+      subnetIds: ${file(./networking.${self:custom.profileRetrievalStage}.yml):subnets}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -3,6 +3,7 @@
 * `build`: AWS resources to facilitate building.
 * `auth0`: Auth0-related resources. CIS is the source of truth
   for these resources, so it's best (for locality) they live here.
+* `infra`: DynamoDB, DAX, etc. Anything required at "runtime".
 
 ## Disclaimer
 

--- a/terraform/infra/README.md
+++ b/terraform/infra/README.md
@@ -1,0 +1,15 @@
+infra
+=====
+
+Generally for dealing with DAX.
+
+To allow the Person API Lambdas to talk with DAX, you'll need to
+get the following out of `terraform output`:
+
+* `lambda_security_group`: a security group, allowing the lambdas to talk to DAX (and DAX to accept traffic from this SG).
+* `private_subnets`: the subnets where we create the Person API lambdas.
+
+We generally prefer to use private subnets because it's easier to
+reason about what kinds of traffic we're going to expect: None.
+The Lambdas are all called via the AWS API Gateway, using AWS's
+APIs, and not via regular channels.

--- a/terraform/infra/dev/.terraform.lock.hcl
+++ b/terraform/infra/dev/.terraform.lock.hcl
@@ -1,0 +1,28 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.2.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:+Qr9xg0yGTwNyrZtYQaBAnyf6BI2+/4JoTWF/kVLa5o=",
+    "h1:Li35IiZOPaw01q7wZmvj1NiUnGUHqX6phrx9OWXU4eI=",
+    "h1:Wzmt/V6yIZaty1TXelM8kzvhfMxx41STHBLilNtgES0=",
+    "h1:ziUjk3KGwBa7bAwZaPuQklfcQ3Qlx2d0rlYFvdZn4g8=",
+    "zh:224b20371f7c7ce14d69a84e16ae94baa0a06c132474d4bc4d192d86936bc750",
+    "zh:2c079ad275c32b9abae7616d07c24901340207a85995ce0025ac38af16b317b7",
+    "zh:2d139c99d6e8e48cc5439c2945eee583bb3a2d7faf484639cdfd4590ebc294f2",
+    "zh:2f2dc72de43d845e5df5a1adeadd4a48f3cacfe413b89b95f50294a386a90124",
+    "zh:304d4e706ac34aba080a81867209c65cdd28f8e596c02b3565f6530ab697cf94",
+    "zh:40e69328ae11fe1711b34226d45aa4c685f73e8f958c76c49f4f6a6627a1a54f",
+    "zh:5c5c9faab6fe242b77f0d0ab6664313dd89409371123e2ec376c72e8f2cd97b3",
+    "zh:7824709f0226afec5e3ad41392233b4bd7d925bae0d35f4a2ac854b3516e955c",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ab5417435121e8f9a6f539a6972f20c060ebc78624c1ce7c190671f163c423e4",
+    "zh:d6939385de4931f9fe07c87b744468fbfa96bd4b47861020d68e7ba1efb4185f",
+    "zh:e51434d1ba106c55d04fdc223aaf403b897ff96cba9bfce4c51854c805c36ed8",
+    "zh:e6d1012bafe338759ac42a59f566f8c4ad64a67faa3152c7fb758704d890cd75",
+    "zh:ee24b989ee3b6be79a7f24e97c144535bf7053471ae65343220db3ae78c7632a",
+    "zh:f61ec9482b9887c4901946407992874531b0c2eadab0c743fdfca4e6cd6dd889",
+  ]
+}

--- a/terraform/infra/dev/dax.tf
+++ b/terraform/infra/dev/dax.tf
@@ -1,0 +1,91 @@
+variable "dax_replicas" {
+  type    = number
+  default = 1
+}
+
+data "aws_dynamodb_table" "identity_vault" {
+  name = "${var.environment}-identity-vault"
+}
+
+data "aws_iam_policy_document" "cis_read_access" {
+  statement {
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      "${data.aws_dynamodb_table.identity_vault.arn}",
+      "${data.aws_dynamodb_table.identity_vault.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dax_cis_read_access" {
+  name   = "AWSDaxCISReadAccess"
+  policy = data.aws_iam_policy_document.cis_read_access.json
+}
+
+resource "aws_iam_role" "dax_cis" {
+  name = "AWSDaxCIS"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid    = "DaxAssumeRole"
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "dax.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "dax_cis_read" {
+  role       = aws_iam_role.dax_cis.name
+  policy_arn = aws_iam_policy.dax_cis_read_access.arn
+}
+
+resource "aws_dax_parameter_group" "cache" {
+  name        = "cis-cache"
+  description = "DAX parameter group. Generally for caching Scan operations."
+  # Cache query/scan results for 2 hours -- the same amount of time we keep our
+  # S3 cache around for.
+  parameters {
+    name  = "query-ttl-millis"
+    value = "7200000"
+  }
+  # DANGER: We really shouldn't be using this unless we support cache
+  # write-through.
+  #
+  # I'm (bhee) justifying it for scan results, since that's _existing_
+  # behaviour (S3 cache). I'm unsure what the behaviour of returning
+  # potentially stale user profiles will be.
+  parameters {
+    name  = "record-ttl-millis"
+    value = "30000"
+  }
+}
+
+resource "aws_dax_cluster" "cache" {
+  # Max length: 20 characters
+  cluster_name         = "${var.environment}-id"
+  parameter_group_name = aws_dax_parameter_group.cache.name
+  # The cheapest available that would comfortably fit a large chunk of our
+  # dataset in memory.
+  node_type = "dax.r7i.large"
+  # For development, let's just use the one.
+  replication_factor = var.dax_replicas
+  iam_role_arn       = aws_iam_role.dax_cis.arn
+  # 1AM - 3AM (UTC); 6PM - 8PM PDT; 9PM - 11PM EDT.
+  maintenance_window               = "sat:01:00-sat:03:00"
+  cluster_endpoint_encryption_type = "TLS"
+  availability_zones               = slice(keys(local.subnet_azs), 0, var.dax_replicas)
+  subnet_group_name                = aws_dax_subnet_group.cis.name
+  security_group_ids               = [aws_security_group.dax.id]
+  server_side_encryption {
+    enabled = true
+  }
+}

--- a/terraform/infra/dev/defaults.auto.tfvars
+++ b/terraform/infra/dev/defaults.auto.tfvars
@@ -1,0 +1,2 @@
+environment  = "development"
+dax_replicas = 1

--- a/terraform/infra/dev/networking.tf
+++ b/terraform/infra/dev/networking.tf
@@ -1,0 +1,180 @@
+# For current VPC allocations, see:
+# https://mozilla-hub.atlassian.net/wiki/spaces/IAM/database/1695515017
+
+locals {
+  subnet_azs = {
+    "us-west-2a" : 0,
+    "us-west-2b" : 1,
+    "us-west-2c" : 2,
+  }
+  public_subnet_azs = {
+    "us-west-2a" : 0,
+    "us-west-2b" : 1,
+    "us-west-2c" : 2,
+  }
+}
+
+resource "aws_vpc" "cis" {
+  cidr_block                       = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+  enable_dns_hostnames             = true
+  tags = {
+    Name = "${var.environment}-cis"
+  }
+}
+
+resource "aws_subnet" "public" {
+  for_each                                       = local.public_subnet_azs
+  vpc_id                                         = aws_vpc.cis.id
+  availability_zone                              = each.key
+  cidr_block                                     = cidrsubnet(aws_vpc.cis.cidr_block, 8, length(local.subnet_azs) + each.value)
+  ipv6_cidr_block                                = cidrsubnet(aws_vpc.cis.ipv6_cidr_block, 8, length(local.subnet_azs) + each.value)
+  assign_ipv6_address_on_creation                = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  enable_resource_name_dns_a_record_on_launch    = true
+  tags = {
+    Name = "${var.environment}-public-${each.key}"
+  }
+}
+
+resource "aws_default_route_table" "default" {
+  default_route_table_id = aws_vpc.cis.default_route_table_id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.default.id
+  }
+  route {
+    ipv6_cidr_block = "::/0"
+    gateway_id      = aws_internet_gateway.default.id
+  }
+  tags = {
+    Name = "${var.environment}-cis"
+  }
+}
+
+resource "aws_egress_only_internet_gateway" "default" {
+  vpc_id = aws_vpc.cis.id
+  tags = {
+    Name = "${var.environment}-cis"
+  }
+}
+
+resource "aws_internet_gateway" "default" {
+  vpc_id = aws_vpc.cis.id
+}
+
+resource "aws_eip" "nat" {
+  for_each         = local.subnet_azs
+  domain           = "vpc"
+  public_ipv4_pool = "amazon"
+  tags = {
+    Name = "${var.environment}-cis-nat-${each.key}"
+  }
+}
+
+resource "aws_nat_gateway" "cis" {
+  for_each          = local.subnet_azs
+  allocation_id     = aws_eip.nat[each.key].id
+  subnet_id         = aws_subnet.public[each.key].id
+  connectivity_type = "public"
+  tags = {
+    Name = "${var.environment}-cis-${each.key}"
+  }
+}
+
+resource "aws_subnet" "private" {
+  for_each                                       = local.subnet_azs
+  vpc_id                                         = aws_vpc.cis.id
+  availability_zone                              = each.key
+  cidr_block                                     = cidrsubnet(aws_vpc.cis.cidr_block, 8, each.value)
+  ipv6_cidr_block                                = cidrsubnet(aws_vpc.cis.ipv6_cidr_block, 8, each.value)
+  assign_ipv6_address_on_creation                = true
+  enable_resource_name_dns_aaaa_record_on_launch = true
+  enable_resource_name_dns_a_record_on_launch    = true
+  tags = {
+    Name = "${var.environment}-${each.key}"
+  }
+}
+
+output "private_subnets" {
+  value = [for subnet in aws_subnet.private : subnet.id]
+}
+
+resource "aws_route_table" "private" {
+  for_each = local.subnet_azs
+  vpc_id   = aws_vpc.cis.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.cis[each.key].id
+  }
+  route {
+    ipv6_cidr_block        = "::/0"
+    egress_only_gateway_id = aws_egress_only_internet_gateway.default.id
+  }
+  tags = {
+    Name = "${var.environment}-cis-${each.key}"
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = local.subnet_azs
+  subnet_id      = aws_subnet.private[each.key].id
+  route_table_id = aws_route_table.private[each.key].id
+}
+
+resource "aws_dax_subnet_group" "cis" {
+  name       = "${var.environment}-id"
+  subnet_ids = [for subnet in aws_subnet.private : subnet.id]
+}
+
+resource "aws_security_group" "dax" {
+  name        = "dax"
+  description = "Allow connections to and from AWS Dax."
+  vpc_id      = aws_vpc.cis.id
+  tags = {
+    Name = "${var.environment}-dax"
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "lambda_dax" {
+  security_group_id            = aws_security_group.dax.id
+  referenced_security_group_id = aws_security_group.lambda.id
+  ip_protocol                  = -1
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "lambda"
+  description = "Allow all connections."
+  vpc_id      = aws_vpc.cis.id
+  tags = {
+    Name = "${var.environment}-cis-lambdas"
+  }
+}
+
+output "lambda_security_group" {
+  value = aws_security_group.lambda.id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "lambda_all4" {
+  security_group_id = aws_security_group.lambda.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = -1
+}
+
+resource "aws_vpc_security_group_ingress_rule" "lambda_all6" {
+  security_group_id = aws_security_group.lambda.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = -1
+}
+
+resource "aws_vpc_security_group_egress_rule" "lambda_all4" {
+  security_group_id = aws_security_group.lambda.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = -1
+}
+
+resource "aws_vpc_security_group_egress_rule" "lambda_all6" {
+  security_group_id = aws_security_group.lambda.id
+  cidr_ipv6         = "::/0"
+  ip_protocol       = -1
+}

--- a/terraform/infra/dev/provider.tf
+++ b/terraform/infra/dev/provider.tf
@@ -1,0 +1,31 @@
+# Locked with:
+# terraform providers lock -platform darwin_amd64 -platform darwin_arm64 -platform linux_amd64 -platform linux_arm64
+terraform {
+  required_version = ">= 1.5.0"
+  backend "s3" {
+    # Re-using the one from mozilla-iam/iam-infra, to save having multiple
+    # places to audit.
+    bucket = "eks-terraform-shared-state"
+    key    = "cis/terraform/infra/dev/terraform.tfstate"
+    region = "us-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+  default_tags {
+    tags = {
+      Component      = "CIS"
+      FunctionalArea = "SSO"
+      Owner          = "IAM"
+      Repository     = "github.com/mozilla-iam/cis"
+      Environment    = var.environment
+    }
+  }
+}

--- a/terraform/infra/dev/variables.tf
+++ b/terraform/infra/dev/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}


### PR DESCRIPTION
DAX promises to improve our response times from DynamoDB. This PR makes use of DAX in the route that's currently timing out, causing the HRIS sync job to fail.

A small writeup with results is available on [the internal wiki](https://mozilla-hub.atlassian.net/wiki/spaces/IAM/pages/edit-v2/1704691299). But, the important bits are:

* we don't see an improvement for the failing query on development;
* we may see an improvement on staging, where we have more data.

Jira: [IAM-1668](https://mozilla-hub.atlassian.net/browse/IAM-1668)