### PR TITLE
ci Replaced with a repository variable

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -19,4 +19,3 @@ jobs:
       gar_name: iam-prod
       project_id: moz-fx-iam-prod
       should_tag_ghcr: true
-      workload_identity_pool_project_number: 324168772199


### PR DESCRIPTION
We'll want to consider making this an org-level variable, something which I'm not able to do at the moment.

Jira: IAM-1735