### PR TITLE
feat(terraform): Our GKE workloads will require AWS access

### DIFF
--- a/terraform/infra/common/.terraform.lock.hcl
+++ b/terraform/infra/common/.terraform.lock.hcl
@@ -1,0 +1,50 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.8.0"
+  constraints = ">= 4.37.0, ~> 6.0"
+  hashes = [
+    "h1:AKzP2NxGfL915FP9CDJacRHmDeKB+V96OfpbLaQuPVM=",
+    "h1:BfoqVUq+X9n0jRpsZazxIjcKKuvjsn90FuNfQ2pCy5o=",
+    "h1:HDnB+foDh9HJd81T+ddn2tC0DXonSUwovBdvuKe9dZs=",
+    "h1:XBPnFkWH72A3neGLdAqyd8HXfXziS8NS4BrEc021ajQ=",
+    "zh:04781915164a85316d2f659383bb4a2c26ce258efdd63b10ebf5dc741b13d3a4",
+    "zh:050eba0f1d40b6a2542206742fbf8697b139e045120e50b59fa090eb1babb46d",
+    "zh:0590b7ba32f211142fc1acc1350560ce47faa287aeec697b577c9fe10e0efcab",
+    "zh:279943444a858c38976b30248bdcf968ff4b536b9cd8054e7475b8e493c67a16",
+    "zh:46c556c8753d31fdb98123ba3437e6eded07d7671c2cbfc127b2c315f82c0899",
+    "zh:5f6943dfd9e44458b6b915a64f5e103b0e7cff98bf804bb95b8eedaa9c6cc786",
+    "zh:6456d583155ce05028517425a5b5057a05978a89f90df29f37c5c2295e37f605",
+    "zh:83fc4712f0a972b13be71e4323982f55687fb431e1657c91854d3ec8ff846dfb",
+    "zh:921d2761e8474eb12cde03e57dba127021edff8423183241528514351519f721",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f7e13279fcb9ca3e775cbda837735d6868c2fc966e7c23aa27607838ce06c11",
+    "zh:a21075ba6cf6345ed2b28c64bd52af3871d3957f8ca13dbce488975c8b496cbc",
+    "zh:c2e05b36d5d1eb106eb1e763fca9b9ea9e0e5f9900c773b5a80678b66229cfc1",
+    "zh:f340a9a4b67d3f63f36e68ba73145900b7c5cb774d7716aef0600e853fad910e",
+    "zh:f5ce5af7e58f7b3a06b902efb953b64895e5c70c203fc9cdeeb75db240abba31",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.1.0"
+  hashes = [
+    "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "h1:UklaKJOCynnEJbpCVN0zJKIJ3SvO7RQJ00/6grBatnw=",
+    "h1:uDtqTpFJOseNUlPDx4TT/lXf6ie3CarsimL7sYCiVH4=",
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/terraform/infra/common/oidc_gke.tf
+++ b/terraform/infra/common/oidc_gke.tf
@@ -1,0 +1,17 @@
+# From:
+# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-public-nonprod-us-west1.yaml
+module "oidc_gke_webservices_high_public_nonprod" {
+  source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
+  gcp_region       = "us-west1"
+  gcp_project_id   = "moz-fx-webservices-high-nonpro"
+  gke_cluster_name = "webservices-high-public-nonprod-us-west1"
+}
+
+# From:
+# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-public-prod-us-west1.yaml
+module "oidc_gke_webservices_high_public_prod" {
+  source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
+  gcp_region       = "us-west1"
+  gcp_project_id   = "moz-fx-webservices-high-prod"
+  gke_cluster_name = "webservices-high-public-prod-us-west1"
+}

--- a/terraform/infra/common/oidc_gke.tf
+++ b/terraform/infra/common/oidc_gke.tf
@@ -1,17 +1,17 @@
 # From:
-# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-public-nonprod-us-west1.yaml
-module "oidc_gke_webservices_high_public_nonprod" {
+# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-private-nonprod-us-west1.yaml
+module "oidc_gke_webservices_high_private_nonprod" {
   source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
   gcp_region       = "us-west1"
   gcp_project_id   = "moz-fx-webservices-high-nonpro"
-  gke_cluster_name = "webservices-high-public-nonprod-us-west1"
+  gke_cluster_name = "webservices-high-private-nonprod-us-west1"
 }
 
 # From:
-# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-public-prod-us-west1.yaml
-module "oidc_gke_webservices_high_public_prod" {
+# https://github.com/mozilla/global-platform-admin/blob/d3ba91536f92d2de15c9fc0f22a216f0d6cadc59/platform-shared/k8s/bootstrap/webservices-high-private-prod-us-west1.yaml
+module "oidc_gke_webservices_high_private_prod" {
   source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
   gcp_region       = "us-west1"
   gcp_project_id   = "moz-fx-webservices-high-prod"
-  gke_cluster_name = "webservices-high-public-prod-us-west1"
+  gke_cluster_name = "webservices-high-private-prod-us-west1"
 }

--- a/terraform/infra/common/provider.tf
+++ b/terraform/infra/common/provider.tf
@@ -1,0 +1,31 @@
+# Locked with:
+# terraform providers lock -platform darwin_amd64 -platform darwin_arm64 -platform linux_amd64 -platform linux_arm64
+terraform {
+  required_version = ">= 1.5.0"
+  backend "s3" {
+    # Re-using the one from mozilla-iam/iam-infra, to save having multiple
+    # places to audit.
+    bucket = "eks-terraform-shared-state"
+    key    = "cis/terraform/infra/common/terraform.tfstate"
+    region = "us-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+  default_tags {
+    tags = {
+      Component      = "CIS"
+      FunctionalArea = "SSO"
+      Owner          = "IAM"
+      Repository     = "github.com/mozilla-iam/cis"
+      ManagedBy      = "Terraform"
+    }
+  }
+}

--- a/terraform/infra/dev/defaults.auto.tfvars
+++ b/terraform/infra/dev/defaults.auto.tfvars
@@ -1,5 +1,5 @@
 environment      = "development"
 gcp_region       = "us-west1"
-gke_cluster_name = "webservices-high-public-nonprod-us-west1"
+gke_cluster_name = "webservices-high-private-nonprod-us-west1"
 gcp_project_id   = "moz-fx-webservices-high-nonpro"
 gke_namespace    = "iam-dev"

--- a/terraform/infra/dev/defaults.auto.tfvars
+++ b/terraform/infra/dev/defaults.auto.tfvars
@@ -1,1 +1,5 @@
-environment = "development"
+environment      = "development"
+gcp_region       = "us-west1"
+gke_cluster_name = "webservices-high-public-nonprod-us-west1"
+gcp_project_id   = "moz-fx-webservices-high-nonpro"
+gke_namespace    = "iam-dev"

--- a/terraform/infra/dev/iam_gke.tf
+++ b/terraform/infra/dev/iam_gke.tf
@@ -1,0 +1,37 @@
+# Depends on ../common.
+
+data "aws_region" "current" {}
+
+# From: serverless-functions/profile_retrieval/serverless.yml
+data "aws_iam_policy_document" "dynamo_read" {
+  statement {
+    sid = "AllowRead"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      aws_dynamodb_table.dynamo.arn,
+      "${aws_dynamodb_table.dynamo.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cis_dynamo_read" {
+  name   = "CISDynamoRead"
+  policy = data.aws_iam_policy_document.dynamo_read.json
+}
+
+module "cis_profile_retrieval_api" {
+  source              = "github.com/mozilla/terraform-modules//aws_gke_oidc_role?ref=aws_gke_oidc_config-0.1.0"
+  role_name           = "GKE${title(var.environment)}CISProfileRetrievalAPI"
+  aws_region          = data.aws_region.current.region
+  gcp_region          = var.gcp_region
+  gke_cluster_name    = var.gke_cluster_name
+  gcp_project_id      = var.gcp_project_id
+  gke_namespace       = var.gke_namespace
+  gke_service_account = "cis-profile-retrieval-api"
+  iam_policy_arns     = [aws_iam_policy.cis_dynamo_read.arn]
+}

--- a/terraform/infra/dev/variables.tf
+++ b/terraform/infra/dev/variables.tf
@@ -1,3 +1,19 @@
 variable "environment" {
   type = string
 }
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "gke_cluster_name" {
+  type = string
+}
+
+variable "gcp_project_id" {
+  type = string
+}
+
+variable "gke_namespace" {
+  type = string
+}


### PR DESCRIPTION
See also:

* https://github.com/mozilla/global-platform-admin/pull/3879 -- ~changing the cluster type to `public`~, asking Argo to deploy a chart;
* https://github.com/mozilla/webservices-infra/pull/6860 -- adding a chart and various infra bits.

Jira: [IAM-1735](https://mozilla-hub.atlassian.net/browse/IAM-1735)


---

todo checklist:

* [x] add roles