### PR TITLE
fix(terraform): Correct assumptions around naming

### DIFF
--- a/terraform/infra/common/oidc_gke.tf
+++ b/terraform/infra/common/oidc_gke.tf
@@ -4,7 +4,7 @@ module "oidc_gke_webservices_high_private_nonprod" {
   source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
   gcp_region       = "us-west1"
   gcp_project_id   = "moz-fx-webservices-high-nonpro"
-  gke_cluster_name = "webservices-high-private-nonprod-us-west1"
+  gke_cluster_name = "webservices-high-nonprod"
 }
 
 # From:
@@ -13,5 +13,5 @@ module "oidc_gke_webservices_high_private_prod" {
   source           = "github.com/mozilla/terraform-modules//aws_gke_oidc_config?ref=aws_gke_oidc_config-0.1.0"
   gcp_region       = "us-west1"
   gcp_project_id   = "moz-fx-webservices-high-prod"
-  gke_cluster_name = "webservices-high-private-prod-us-west1"
+  gke_cluster_name = "webservices-high-prod"
 }

--- a/terraform/infra/dev/defaults.auto.tfvars
+++ b/terraform/infra/dev/defaults.auto.tfvars
@@ -1,5 +1,5 @@
 environment      = "development"
 gcp_region       = "us-west1"
-gke_cluster_name = "webservices-high-private-nonprod-us-west1"
+gke_cluster_name = "webservices-high-nonprod"
 gcp_project_id   = "moz-fx-webservices-high-nonpro"
 gke_namespace    = "iam-dev"

--- a/terraform/infra/dev/iam_gke.tf
+++ b/terraform/infra/dev/iam_gke.tf
@@ -32,6 +32,6 @@ module "cis_profile_retrieval_api" {
   gke_cluster_name    = var.gke_cluster_name
   gcp_project_id      = var.gcp_project_id
   gke_namespace       = var.gke_namespace
-  gke_service_account = "cis-profile-retrieval-api"
+  gke_service_account = "gha-cis-profile-retrieval-api"
   iam_policy_arns     = [aws_iam_policy.cis_dynamo_read.arn]
 }


### PR DESCRIPTION
* Cluster names were not the same as the filenames;
* The Service Account name was prefixed with `gha`, the release name.

See also:

* https://github.com/mozilla/webservices-infra/pull/6860

Jira: [IAM-1735](https://mozilla-hub.atlassian.net/browse/IAM-1735)