### PR TITLE
IAM-1778: Bump worker/segment count to 128 on profile retrieval service

### DIFF
--- a/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
@@ -55,8 +55,9 @@ def scan(
     logger.debug("Creating new threads and queue.")
     result_queue = queue.Queue()
 
-    pool_size = 24
-    max_segments = 24
+    # The worker pool size should be equal to the max_segments. Ideally we want one segment per worker.
+    pool_size = 128
+    max_segments = 128
 
     users = []
     last_evaluated_key = None


### PR DESCRIPTION
PR ups the number of workers and segments created during a full table scan.  The idea is increasing the worker/segment count should reduce the time it takes to execute a full table scan.  In testing, I was able to decrease the scan time to ~16s.