### PR TITLE
Fix a bug with pagination in Dynamo's parallel scan

### DIFF
--- a/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/models/user.py
@@ -317,15 +317,65 @@ class Profile(object):
             users.extend(response["Items"])
         return users
 
-    def _last_evaluated_to_friendly(self, last_evaluated_key):
-        if last_evaluated_key is None:
+    def _last_evaluated_to_friendly(self, last_evaluated_keys):
+        """
+        Received from Dynamo, and serialized into something our clients can
+        understand (or rather, use: this _should_ be an opaque token to
+        clients).
+
+        When we're paginating through Dynamo, each segment returns a
+        `LastEvaluatedKey`, which we need to specify as `ExclusiveStartKey` in
+        subsequent requests. These `ExclusiveStartKey` is segment-specific,
+        hence the care here to serialize these in the order returned.
+
+        * `None`, indicating that we've completely finished, there are no more
+          results any segment can return;
+        * `list[Optional[Any]]`, indicating that _some_ segments have results
+          left.
+
+        Our clients' pagination logic (at least as seen by various publishers),
+        will consider the query over once we return `None`.
+        """
+        if not last_evaluated_keys:
             return None
+        next_page = []
+        for last_evaluated_key in last_evaluated_keys:
+            # A signal that the segment is done scanning.
+            if last_evaluated_key is None:
+                id = ""
+            else:
+                id = last_evaluated_key["id"]["S"]
+            next_page.append(id)
+        # If there are at all any segments left with work, then continue.
+        if any(next_page):
+            return ",".join(next_page)
         else:
-            return last_evaluated_key["id"]["S"]
+            return None
 
     def _next_page_to_dynamodb(self, next_page):
-        if next_page is not None:
-            return {"id": {"S": next_page}}
+        """
+        Received from _clients_, and deserialized into something our parallel
+        Dynamo code understands.
+
+        A complication here is that we can't reuse `None`, since that would
+        cause a segment to start from the beginning. So, we use a sentinel
+        value of `"done"` to signal to the parallel Dynamo code that we should
+        skip this segment.
+
+        When Dynamo returns `None`, that means _all_ segments are done. If it
+        returns a `list[Optional[Any]]`, that means that we can still make
+        progress on some segments.
+        """
+        if not next_page:
+            return None
+        exclusive_start_keys = []
+        for last_evaluated_key in next_page.split(","):
+            if last_evaluated_key == "":
+                id = "done"
+            else:
+                id = {"id": {"S": last_evaluated_key}}
+            exclusive_start_keys.append(id)
+        return exclusive_start_keys
 
     def all_filtered(self, connection_method=None, active=None, next_page=None):
         """
@@ -352,7 +402,7 @@ class Profile(object):
             filter_expression=filter_expression,
             expression_attr=expression_attr,
             projection_expression=projection_expression,
-            exclusive_start_key=next_page,
+            exclusive_start_keys=next_page,
         )
         return dict(users=response["users"], nextPage=self._last_evaluated_to_friendly(response.get("nextPage")))
 

--- a/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
+++ b/python-modules/cis_identity_vault/cis_identity_vault/parallel_dynamo.py
@@ -78,7 +78,18 @@ def scan(
             max_segments,
         )
 
-        logger.debug(*thread_args)
+        logger.debug(
+            "thread starting scan",
+            extra={
+                "thread_id": thread_id,
+                "table_name": table_name,
+                "filter_expression": filter_expression,
+                "expression_attr": expression_attr,
+                "projection_expression": projection_expression,
+                "exclusive_start_key": exclusive_start_key,
+                "max_segments": max_segments,
+            }
+        )
         threads.append(threading.Thread(target=get_segment, args=thread_args))
         threads[-1].start()
 

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
@@ -1,3 +1,4 @@
+import os
 import orjson
 
 from flask import Flask
@@ -370,7 +371,11 @@ def version():
 
 
 def main():
-    app.run(host="0.0.0.0", debug=True)
+    # DEBT: I think this has been fixed in a later version of Flask.
+    # We don't call this in production, but instead lean on Serverless' WSGI handler.
+    host, _, port = os.environ.get("SERVER_NAME", "127.0.0.1:5000").partition(":")
+    port = int(port)
+    app.run(host=host, port=port, debug=True)
 
 
 if __name__ == "__main__":

--- a/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
+++ b/python-modules/cis_profile_retrieval_service/cis_profile_retrieval_service/v2_api.py
@@ -150,7 +150,6 @@ class v2UsersByAny(Resource):
         parser.add_argument("connectionMethod", type=str, location="args")
         parser.add_argument("active", type=str, location="args")
         parser.add_argument("nextPage", type=str, location="args")
-        parser.add_argument("cached", type=str, location="args")
 
         args = parser.parse_args()
 

--- a/python-modules/cis_profile_retrieval_service/tests/mozilla-cis-mock.ini
+++ b/python-modules/cis_profile_retrieval_service/tests/mozilla-cis-mock.ini
@@ -1,0 +1,15 @@
+# Mozilla-IAM template for configuration of the Mozilla Change Integration Service
+
+[cis]
+# Is the environment running locally, production, staging, or test.
+environment=mock
+
+# AssumeRole arn is required even locally.  Use a dummy fixture if you do not have a role setup.
+assume_role_arn=arn:aws:iam::123456789000:role/demo-assume-role-test
+
+# Set these parameters if you are running locally.
+seed_api_data=true
+
+[person_api]
+jwt_validation=false
+advanced_search=true

--- a/python-modules/cis_profile_retrieval_service/tests/test_e2e.py
+++ b/python-modules/cis_profile_retrieval_service/tests/test_e2e.py
@@ -1,0 +1,65 @@
+"""
+n.b. Do not run this as a part of your development cycle. Do not run this
+regularly. This can, and will, insert weird data into CIS, if misconfigured.
+
+A pseudo-e2e test, where we run the code locally but use dev/stage resources.
+This is the code equivalent of running with scissors.
+
+Requires the following environment variables:
+
+    CIS_ENVIRONMENT="testing"
+    CIS_SEED_API_DATA="false"
+    PERSON_API_ADVANCED_SEARCH="true"
+    PERSON_API_INITIALIZE_VAULT="false"
+    PERSON_API_JWT_VALIDATION="false"
+    SERVER_NAME="127.0.0.1:8000"
+
+Run the server with:
+
+    python cis_profile_retrieval_service/v2_api.py
+
+Run the test with:
+
+    PSEUDO_E2E=yes pytest --log-cli-level=DEBUG tests/test_e2e.py
+
+You'll also need an active AWS session, which is left as an exercise for the
+user.
+"""
+
+import logging
+import os
+import pytest
+import requests
+
+from tests.fake_auth0 import FakeBearer
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+logging.getLogger("faker.factory").setLevel(logging.INFO)
+logging.getLogger("urllib3").setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def auth_headers():
+    bearer = FakeBearer()
+    token = bearer.generate_bearer_with_scope("display:all search:all")
+    headers = {"Authorization": f"Bearer {token}"}
+    return headers
+
+
+@pytest.mark.skipif(os.environ.get("PSEUDO_E2E") is None, reason="Not running in pseudo-E2E mode.")
+def test_retrieve_single_profile(auth_headers):
+    res = requests.get(
+        "http://localhost:8000/v2/users/id/all?connectionMethod=ad&active=True",
+        headers=auth_headers,
+    ).json()
+    next_page = res.get("nextPage")
+    pages = 1
+    while next_page:
+        res = requests.get(
+            f"http://localhost:8000/v2/users/id/all?connectionMethod=ad&active=True&nextPage={next_page}",
+            headers=auth_headers,
+        ).json()
+        next_page = res.get("nextPage")
+        pages += 1
+    assert pages >= 2, "Did not iterate through any pages."

--- a/python-modules/cis_profile_retrieval_service/tests/test_v2_api_pagination.py
+++ b/python-modules/cis_profile_retrieval_service/tests/test_v2_api_pagination.py
@@ -1,0 +1,93 @@
+"""
+A simplification of the existing v2_api tests. We reuse Dynamo and the users we
+create across each test, since otherwise it'll take a while.
+
+See `DEBT` notes for where I ran into weirdness.
+
+Run with:
+
+    pytest --log-cli-level=DEBUG tests/test_v2_api_pagination.py
+
+"""
+
+import logging
+import os
+
+import pytest
+import boto3
+from moto import mock_aws
+from tests.fake_auth0 import FakeBearer, json_form_of_pk
+
+from cis_identity_vault import vault
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(name)s:%(message)s")
+
+# Set to the level where logs become interesting, otherwise our log output
+# becomes too verbose. A pain while testing iteratively.
+logging.getLogger("boto3").setLevel(logging.INFO)
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("faker").setLevel(logging.INFO)
+logging.getLogger("everett").setLevel(logging.INFO)
+logging.getLogger("urllib3").setLevel(logging.INFO)
+logging.getLogger("responses").setLevel(logging.WARNING)
+logging.getLogger("cis_profile").setLevel(logging.INFO)
+logging.getLogger("cis_identity_vault.parallel_dynamo").setLevel(logging.INFO)
+
+logger = logging.getLogger(__name__)
+
+
+# Re-use our AWS mocks module-wide. Related to `identity_vault`.
+def setup_module(module):
+    module.mock = mock_aws(config={"core": {"service_whitelist": ["dynamodb"]}})
+    module.mock.start()
+
+
+def teardown_module(module):
+    module.mock.stop()
+
+
+@pytest.fixture(scope="module")
+def environment():
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("CIS_CONFIG_INI", "tests/mozilla-cis-mock.ini")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "us-west-2")
+        yield monkeypatch
+
+
+# Slow, so reuse across the module.
+@pytest.fixture(scope="module")
+def identity_vault(environment):
+    vault_client = vault.IdentityVault()
+    vault_client.connect()
+    vault_client.create()
+    vault_client.find_or_create()
+    # DEBT: requires side-effects.
+    from cis_profile_retrieval_service.common import seed
+    # DEBT?: doesn't seemingly generate only `number_of_fake_users` users.
+    # DEBT: doesn't generate `ad|Mozilla-LDAP` users.
+    seed(number_of_fake_users=128)
+    return (boto3.client("dynamodb"), boto3.resource("dynamodb"))
+
+
+@pytest.fixture
+def app(environment, monkeypatch):
+    bearer = FakeBearer()
+    token = bearer.generate_bearer_with_scope("display:all search:all")
+    headers = {
+        "Authorization": f"Bearer {token}"
+    }
+    monkeypatch.setattr("cis_profile_retrieval_service.idp.get_jwks", lambda: json_form_of_pk)
+    # DEBT: requires side-effects.
+    from cis_profile_retrieval_service import v2_api
+    v2_api.app.testing = True
+    return (headers, v2_api.app.test_client())
+
+
+def test_existing(identity_vault, app):
+    headers, client = app
+    # DEBT: see note above, about not generating `ad|Mozilla-LDAP` users.
+    results = client.get(
+        "/v2/users/id/all?connectionMethod=github&active=True",
+        headers=headers,
+        follow_redirects=True,
+    )

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 moto==5.0.14
-pytest==6.1.1
+pytest==6.2.5
 pytest-benchmark==3.2.3
 docker==5.0.3


### PR DESCRIPTION
As it turns out, `cis_profile_retrieval_service` was doing the right thing. But, `cis_identity_vault` was not.

Three main issues solved in this PR:

1. `cis_identity_vault`'s parallel scan was paginating for callers, breaking the expectation that pagination was being used, or could have been used.
2. The last page of parallel scans _may_ include duplicate results. At least in the test using mocks. It's unclear if this is the case when running against a real DynamoDB.
3. Adding tests again for `cis_profile_retrieval_service`, which atrophied.

The commit messages are more descriptive than this PR.

Jira: [IAM-1793](https://mozilla-hub.atlassian.net/browse/IAM-1793)